### PR TITLE
Support Let's Encrypt HTTP-01 challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Example of required configuration for Let's Encrypt support:
 
 ```YAML
 listen: 0.0.0.0:443
+listen-http: 0.0.0.0:80
 enable-https-redirection: true
 enable-security-filter: true
 use-letsencrypt: true
@@ -400,7 +401,7 @@ hostnames:
   - domain.tld
 ```
 
-Note: listening on the port 443 is mandatory requirement
+Note: listening on the port 80,443 is mandatory requirement
 
 #### **Access Token Encryption**
 


### PR DESCRIPTION
Per [this announcement](https://community.letsencrypt.org/t/tls-sni-challenges-disabled-for-most-new-issuance/50316), Let's Encrypt disabled TLS-SNI challenge permanently due to a security issue. As a workaround, this patch adds HTTP-01 challenge support to make this feature work again.