### PR TITLE
[KEYCLOAK-9033] Add base URI to OAuth routes

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -32,11 +32,15 @@ func (r *oauthProxy) dropCookie(w http.ResponseWriter, host, name, value string,
 	if r.config.CookieDomain != "" {
 		domain = r.config.CookieDomain
 	}
+	path := r.config.BaseURI
+	if path == "" {
+		path = "/"
+	}
 	cookie := &http.Cookie{
 		Domain:   domain,
 		HttpOnly: r.config.HTTPOnlyCookie,
 		Name:     name,
-		Path:     "/",
+		Path:     path,
 		Secure:   r.config.SecureCookie,
 		Value:    value,
 	}

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -40,6 +40,45 @@ func TestCookieDomainHostHeader(t *testing.T) {
 	assert.Equal(t, cookie.Domain, "127.0.0.1")
 }
 
+func TestCookieBasePath(t *testing.T) {
+	cfg := newFakeKeycloakConfig()
+	cfg.BaseURI = "/base-uri"
+
+	_, _, svc := newTestProxyService(cfg)
+
+	resp, err := makeTestCodeFlowLogin(svc + "/admin")
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	var cookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == "kc-access" {
+			cookie = c
+		}
+	}
+	assert.NotNil(t, cookie)
+	assert.Equal(t, "/base-uri", cookie.Path)
+}
+
+func TestCookieWithoutBasePath(t *testing.T) {
+	cfg := newFakeKeycloakConfig()
+
+	_, _, svc := newTestProxyService(cfg)
+
+	resp, err := makeTestCodeFlowLogin(svc + "/admin")
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	var cookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == "kc-access" {
+			cookie = c
+		}
+	}
+	assert.NotNil(t, cookie)
+	assert.Equal(t, "/", cookie.Path)
+}
+
 func TestCookieDomain(t *testing.T) {
 	p, _, svc := newTestProxyService(nil)
 	p.config.CookieDomain = "domain.com"

--- a/handlers.go
+++ b/handlers.go
@@ -209,10 +209,6 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 			redirectURI = string(decoded)
 		}
 	}
-	if r.config.BaseURI != "" {
-		// assuming state starts with slash
-		redirectURI = r.config.BaseURI + redirectURI
-	}
 
 	r.redirectToURL(redirectURI, w, req, http.StatusTemporaryRedirect)
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -353,6 +353,44 @@ func TestOauthRequests(t *testing.T) {
 	newFakeProxy(cfg).RunTests(t, requests)
 }
 
+func TestOauthRequestsWithBaseURI(t *testing.T) {
+	cfg := newFakeKeycloakConfig()
+	cfg.BaseURI = "/base-uri"
+	requests := []fakeRequest{
+		{
+			URI:          "/base-uri/oauth/authorize",
+			Redirects:    true,
+			ExpectedCode: http.StatusTemporaryRedirect,
+		},
+		{
+			URI:          "/base-uri/oauth/callback",
+			Redirects:    true,
+			ExpectedCode: http.StatusBadRequest,
+		},
+		{
+			URI:          "/base-uri/oauth/health",
+			Redirects:    true,
+			ExpectedCode: http.StatusOK,
+		},
+		{
+			URI:           "/oauth/authorize",
+			ExpectedProxy: true,
+			ExpectedCode:  http.StatusOK,
+		},
+		{
+			URI:           "/oauth/callback",
+			ExpectedProxy: true,
+			ExpectedCode:  http.StatusOK,
+		},
+		{
+			URI:           "/oauth/health",
+			ExpectedProxy: true,
+			ExpectedCode:  http.StatusOK,
+		},
+	}
+	newFakeProxy(cfg).RunTests(t, requests)
+}
+
 func TestMethodExclusions(t *testing.T) {
 	cfg := newFakeKeycloakConfig()
 	cfg.Resources = []*Resource{

--- a/server.go
+++ b/server.go
@@ -196,7 +196,7 @@ func (r *oauthProxy) createReverseProxy() error {
 	}
 
 	// step: add the routing for oauth
-	engine.With(proxyDenyMiddleware).Route(r.config.OAuthURI, func(e chi.Router) {
+	engine.With(proxyDenyMiddleware).Route(r.config.BaseURI+r.config.OAuthURI, func(e chi.Router) {
 		e.MethodNotAllowed(methodNotAllowHandlder)
 		e.HandleFunc(authorizationURL, r.oauthAuthorizationHandler)
 		e.Get(callbackURL, r.oauthCallbackHandler)


### PR DESCRIPTION
This PR implements a simple fix that ensures that keycloak-proxy prefixes the required oauth endpoints with the value defined in the `base-uri` option.

This is required in order to work, for instance, in environments where keycloak-proxy is used behind another reverse proxy that directs traffic to different backends based on the path requested.