### PR TITLE
[KEYCLOAK-8487] Provide gatekeeper binaries for Linux, Windows and OSx

### DIFF
--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+NEW_VERSION=$1
+
+CURRENT=`awk '/release.*=/ { print $3 }' doc.go | sed 's/"//g'`
+sed -i "s/$CURRENT/$NEW_VERSION/g" doc.go 


### PR DESCRIPTION
@stianst I'm sorry for not providing enough details about how to test it. You can run the golang docker image like this to see the output, in this way you don't have to worry about environment setup:

### Building locally

1. Make sure you have the whole setup described here https://developer.fedoraproject.org/tech/languages/go/go-installation.html
2. mkdir -p $GOPATH/src/github.com/keycloak && cd $GOPATH/src/github.com/keycloak && git clone https://github.com/abstractj/keycloak-gatekeeper && cd keycloak-gatekeeper
3. make build-all

### Buiding using a Docker image
```
docker run -it golang sh -c "mkdir -p /go/src/github.com && cd /go/src/github.com && 
git clone https://github.com/abstractj/keycloak-gatekeeper && cd keycloak-gatekeeper && 
git checkout KEYCLOAK-8487 && make build-all && ls bin"
```
It is expected to have 6 binaries inside bin folder:
```
Cloning into 'keycloak-gatekeeper'...
Branch KEYCLOAK-8487 set up to track remote branch KEYCLOAK-8487 from origin.
Switched to a new branch 'KEYCLOAK-8487'
--> Go Version
go version go1.11.1 linux/amd64
--> Installing build dependencies
make[1]: Entering directory '/go/src/github.com/keycloak-gatekeeper'
--> Installing dependencies
make[1]: Leaving directory '/go/src/github.com/keycloak-gatekeeper'
keycloak-gatekeeper-darwin-386    keycloak-gatekeeper-linux-386    keycloak-gatekeeper-windows-386.exe
keycloak-gatekeeper-darwin-amd64  keycloak-gatekeeper-linux-amd64  keycloak-gatekeeper-windows-amd64.exe
```
