### PR TITLE
Add option to select oauth auth method

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,6 +49,7 @@ func newDefaultConfig() *Config {
 		MaxIdleConns:                100,
 		MaxIdleConnsPerHost:         50,
 		OAuthURI:                    "/oauth",
+		OAuthAuthMethod:             "basic",
 		OpenIDProviderTimeout:       30 * time.Second,
 		PreserveHost:                false,
 		SelfSignedTLSExpiration:     3 * time.Hour,
@@ -62,6 +63,7 @@ func newDefaultConfig() *Config {
 		SkipOpenIDProviderTLSVerify: false,
 		SkipUpstreamTLSVerify:       true,
 		Tags: make(map[string]string, 0),
+
 		UpstreamExpectContinueTimeout: 10 * time.Second,
 		UpstreamKeepaliveTimeout:      10 * time.Second,
 		UpstreamKeepalives:            true,
@@ -188,6 +190,9 @@ func (r *Config) isValid() error {
 				if _, err := url.Parse(r.StoreURL); err != nil {
 					return fmt.Errorf("the store url is invalid, error: %s", err)
 				}
+			}
+			if r.OAuthAuthMethod != "basic" && r.OAuthAuthMethod != "post" {
+				return fmt.Errorf("invalid oauth auth method %q (valid values: basic, post)", r.OAuthAuthMethod)
 			}
 		}
 		// check: ensure each of the resource are valid

--- a/config_test.go
+++ b/config_test.go
@@ -35,39 +35,44 @@ func TestIsConfig(t *testing.T) {
 		},
 		{
 			Config: &Config{
-				DiscoveryURL: "http://127.0.0.1:8080",
+				DiscoveryURL:    "http://127.0.0.1:8080",
+				OAuthAuthMethod: "basic",
 			},
 		},
 		{
 			Config: &Config{
-				DiscoveryURL: "http://127.0.0.1:8080",
-				ClientID:     "client",
-				ClientSecret: "client",
+				DiscoveryURL:    "http://127.0.0.1:8080",
+				OAuthAuthMethod: "basic",
+				ClientID:        "client",
+				ClientSecret:    "client",
 			},
 		},
 		{
 			Config: &Config{
-				Listen:         ":8080",
-				DiscoveryURL:   "http://127.0.0.1:8080",
-				ClientID:       "client",
-				ClientSecret:   "client",
-				RedirectionURL: "http://120.0.0.1",
+				Listen:          ":8080",
+				DiscoveryURL:    "http://127.0.0.1:8080",
+				OAuthAuthMethod: "basic",
+				ClientID:        "client",
+				ClientSecret:    "client",
+				RedirectionURL:  "http://120.0.0.1",
 			},
 		},
 		{
 			Config: &Config{
-				Listen:         ":8080",
-				DiscoveryURL:   "http://127.0.0.1:8080",
-				ClientID:       "client",
-				ClientSecret:   "client",
-				RedirectionURL: "http://120.0.0.1",
-				Upstream:       "http://120.0.0.1",
+				Listen:          ":8080",
+				DiscoveryURL:    "http://127.0.0.1:8080",
+				OAuthAuthMethod: "basic",
+				ClientID:        "client",
+				ClientSecret:    "client",
+				RedirectionURL:  "http://120.0.0.1",
+				Upstream:        "http://120.0.0.1",
 			},
 		},
 		{
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				OAuthAuthMethod:     "basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -81,6 +86,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				OAuthAuthMethod:     "basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -93,6 +99,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				OAuthAuthMethod:     "basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -103,12 +110,13 @@ func TestIsConfig(t *testing.T) {
 		},
 		{
 			Config: &Config{
-				Listen:         ":8080",
-				DiscoveryURL:   "http://127.0.0.1:8080",
-				ClientID:       "client",
-				ClientSecret:   "client",
-				RedirectionURL: "http://120.0.0.1",
-				Upstream:       "http://120.0.0.1",
+				Listen:          ":8080",
+				DiscoveryURL:    "http://127.0.0.1:8080",
+				OAuthAuthMethod: "basic",
+				ClientID:        "client",
+				ClientSecret:    "client",
+				RedirectionURL:  "http://120.0.0.1",
+				Upstream:        "http://120.0.0.1",
 				MatchClaims: map[string]string{
 					"test": "&&&[",
 				},
@@ -129,6 +137,7 @@ func TestIsConfig(t *testing.T) {
 		{
 			Config: &Config{
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				OAuthAuthMethod:     "basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -141,6 +150,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				OAuthAuthMethod:     "basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -152,6 +162,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				OAuthAuthMethod:     "basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -164,6 +175,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				OAuthAuthMethod:     "basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -177,6 +189,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				OAuthAuthMethod:     "basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "https://120.0.0.1",

--- a/doc.go
+++ b/doc.go
@@ -166,6 +166,8 @@ type Config struct {
 	BaseURI string `json:"base-uri" yaml:"base-uri" usage:"common prefix for all URIs" env:"BASE_URI"`
 	// OAuthURI is the uri for the oauth endpoints for the proxy
 	OAuthURI string `json:"oauth-uri" yaml:"oauth-uri" usage:"the uri for proxy oauth endpoints" env:"OAUTH_URI"`
+	// OAuthAuthMethod defines the method for authenticating the oauth client to the server
+	OAuthAuthMethod string `json:"oauth-auth-method" yaml:"oauth-auth-method" usage:"the auth method to use with oauth (basic, post)" env:"OAUTH_AUTH_METHOD"`
 	// Scopes is a list of scope we should request
 	Scopes []string `json:"scopes" yaml:"scopes" usage:"list of scopes requested when authenticating the user"`
 	// Upstream is the upstream endpoint i.e whom were proxying to

--- a/oauth.go
+++ b/oauth.go
@@ -36,7 +36,7 @@ func (r *oauthProxy) getOAuthClient(redirectionURL string, oauthAuthMethod strin
 			ID:     r.config.ClientID,
 			Secret: r.config.ClientSecret,
 		},
-		AuthMethod:  oauth2.AuthMethodClientSecretBasic,
+		AuthMethod:  oauthAuthMethod,
 		AuthURL:     r.idp.AuthEndpoint.String(),
 		RedirectURL: redirectionURL,
 		Scope:       append(r.config.Scopes, oidc.DefaultScope...),

--- a/oauth.go
+++ b/oauth.go
@@ -30,7 +30,7 @@ import (
 )
 
 // getOAuthClient returns a oauth2 client from the openid client
-func (r *oauthProxy) getOAuthClient(redirectionURL string) (*oauth2.Client, error) {
+func (r *oauthProxy) getOAuthClient(redirectionURL string, oauthAuthMethod string) (*oauth2.Client, error) {
 	return oauth2.NewClient(r.idpClient, oauth2.Config{
 		Credentials: oauth2.ClientCredentials{
 			ID:     r.config.ClientID,


### PR DESCRIPTION
Hi,

**TL;DR:**
This PR implements a config option to choose between basic and post authentication during communication between OAuth client and OAuth server. :v:

**Background**:
I am currently building a kubernetes infrastructure for one of my clients and stumbled across this issue yesterday during implementing this gatekeeper as an OIDC proxy for https://onelogin.com .  The issue I ran into is the following: https://stackoverflow.com/questions/52635508/what-is-the-meaning-of-this-error-client-authentication-must-only-be-provided , which states to use either basic *or* post authentication. 🤔

Due to the fact that the gatekeeper is still using go-oidc v1 (as decided and argued about in #407) it is still having a bug as described in coreos/go-oidc#181 which sets the post authentication even when basic is used, so the only quick chance for me to get this one up and running is to implement a config option to let the user choose between basic and post auth (which fixes the problem for me, tested with custom build in my cluster). 😑