### PR TITLE
Fix warning message for invalid groups

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -316,7 +316,7 @@ func (r *oauthProxy) admissionMiddleware(resource *Resource) func(http.Handler) 
 
 			// @step: check if we have any groups, the groups are there
 			if !hasAccess(resource.Groups, user.groups, false) {
-				r.log.Warn("access denied, invalid roles",
+				r.log.Warn("access denied, invalid groups",
 					zap.String("access", "denied"),
 					zap.String("email", user.email),
 					zap.String("resource", resource.URL),

--- a/session.go
+++ b/session.go
@@ -52,7 +52,8 @@ func (r *oauthProxy) getIdentity(req *http.Request) (*userContext, error) {
 		zap.String("id", user.id),
 		zap.String("name", user.name),
 		zap.String("email", user.email),
-		zap.String("roles", strings.Join(user.roles, ",")))
+		zap.String("roles", strings.Join(user.roles, ",")),
+		zap.String("groups", strings.Join(user.groups, ",")))
 
 	return user, nil
 }


### PR DESCRIPTION
This PR fixes a warning related to invalid groups which caused a bit of confusion. It also adds the user's groups to a debug statement to make access issues relating to groups a bit easier to debug.