### PR TITLE
[KEYCLOAK-9127] CSRF support when using credentials in cookies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -110,6 +110,30 @@
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 
 [[projects]]
+  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:9743f0cd7701650c06594b456a1a4bfd563af1288ec449d30ff42f224b7989e7"
+  name = "github.com/gorilla/csrf"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d1620373958b3d521d88c063d1c9b678e734e9df"
+
+[[projects]]
+  digest = "1:e72d1ebb8d395cf9f346fd9cbc652e5ae222dd85e0ac842dc57f175abed6d195"
+  name = "github.com/gorilla/securecookie"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e59506cc896acb7f7bf732d4fdf5e25f7ccd8983"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:97b065743ec8322fed8aa54afc3ae82fea9cdd15ea7a82c90a8d081e0e6f0bbf"
   name = "github.com/jonboulle/clockwork"
   packages = ["."]
@@ -122,6 +146,14 @@
   packages = ["pbutil"]
   pruneopts = "UT"
   revision = "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
+
+[[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   digest = "1:08413c4235cad94a96c39e1e2f697789733c4a87d1fdf06b412d2cf2ba49826a"
@@ -327,6 +359,7 @@
     "github.com/fsnotify/fsnotify",
     "github.com/go-chi/chi/middleware",
     "github.com/go-resty/resty",
+    "github.com/gorilla/csrf",
     "github.com/pressly/chi",
     "github.com/pressly/chi/middleware",
     "github.com/prometheus/client_golang/prometheus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,6 +49,10 @@
   branch = "master"
   name = "github.com/urfave/cli"
 
+[[constraint]]
+  branch = "master"
+  name = "github.com/gorilla/csrf"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/cookies.go
+++ b/cookies.go
@@ -43,7 +43,6 @@ func (r *oauthProxy) dropCookie(w http.ResponseWriter, host, name, value string,
 	if !r.config.EnableSessionCookies && duration != 0 {
 		cookie.Expires = time.Now().Add(duration)
 	}
-
 	http.SetCookie(w, cookie)
 }
 

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -1,0 +1,739 @@
+/*
+Copyright 2015 All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/pressly/chi"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	e2eUpstreamURL       = "/upstream"
+	e2eUpstreamURL2      = "/upstream2"
+	e2eUpstreamListener  = "127.0.0.1:12345"
+	e2eProxyListener     = "127.0.0.1:54321"
+	e2eOauthListener     = "127.0.0.1:23456"
+	e2eAppListener       = "127.0.0.1:34567"
+	e2eOauthURL          = "/auth/realms/hod-test/.well-known/openid-configuration"
+	e2eOauthAuthorizeURL = "/auth/realms/hod-test/protocol/openid-connect/auth"
+	// #nosec
+	e2eOauthTokenURL = "/auth/realms/hod-test/protocol/openid-connect/token"
+	e2eOauthJWKSURL  = "/auth/realms/hod-test/protocol/openid-connect/certs"
+	e2eAppURL        = "/ok"
+)
+
+// checkListenOrBail waits on a endpoint listener to respond.
+// This avoids race conditions with test listieners as go routines
+func checkListenOrBail(endpoint string) bool {
+	const (
+		maxWaitCycles = 10
+		waitTime      = 100 * time.Millisecond
+	)
+	checkListen := http.Client{}
+	_, err := checkListen.Get(endpoint)
+	limit := 0
+	for err != nil && limit < maxWaitCycles {
+		time.Sleep(waitTime)
+		_, err = checkListen.Get(endpoint)
+		limit++
+	}
+	return limit < maxWaitCycles
+}
+
+func runTestApp(t *testing.T) error {
+	go func() {
+		appHandler := func(w http.ResponseWriter, req *http.Request) {
+			_, _ = io.WriteString(w, `{"message": "ok"}`)
+			w.Header().Set("Content-Type", "application/json")
+		}
+		http.HandleFunc(e2eAppURL, appHandler)
+		_ = http.ListenAndServe(e2eAppListener, nil)
+	}()
+	if !assert.True(t, checkListenOrBail("http://"+path.Join(e2eAppListener, e2eAppURL))) {
+		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+path.Join(e2eAppListener, e2eAppURL))
+		t.Logf("%v", err)
+		t.FailNow()
+		return err
+	}
+	return nil
+}
+
+func runTestGatekeeper(t *testing.T, config *Config) error {
+	proxy, err := newProxy(config)
+	if err != nil {
+		return err
+	}
+	_ = proxy.Run()
+	if !assert.True(t, checkListenOrBail("http://"+config.Listen+"/oauth/login")) {
+		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+config.Listen+"/oauth/login")
+		t.Logf("%v", err)
+		t.FailNow()
+		return err
+	}
+	return nil
+}
+
+func runTestUpstream(t *testing.T) error {
+	// a stub upstream API server
+	go func() {
+		getUpstream := func(w http.ResponseWriter, req *http.Request) {
+			// don't expect to see gatekeeper-generated cookies here
+			for _, ck := range req.Cookies() {
+				switch ck.Name {
+				case "kc-access", "kc-csrf":
+					assert.Equal(t, "censored", ck.Value)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Upstream-Response-Header", "test")
+			_, _ = io.WriteString(w, `{"message": "test"}`)
+		}
+
+		postUpstream := func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Upstream-Response-Header", "test")
+			_, _ = io.WriteString(w, `{"message": "posted"}`)
+		}
+
+		deleteUpstream := func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Upstream-Response-Header", "test")
+			_, _ = io.WriteString(w, `{"message": "deleted"}`)
+		}
+
+		upstream := chi.NewRouter()
+		upstream.Route(e2eUpstreamURL, func(r chi.Router) {
+			r.Get("/", getUpstream)
+			r.Post("/", postUpstream)
+			r.Delete("/", deleteUpstream)
+		})
+		upstream.Route(e2eUpstreamURL2, func(r chi.Router) {
+			r.Get("/", getUpstream)
+			r.Post("/", postUpstream)
+			r.Delete("/", deleteUpstream)
+		})
+
+		_ = http.ListenAndServe(e2eUpstreamListener, upstream)
+	}()
+	if !assert.True(t, checkListenOrBail("http://"+path.Join(e2eUpstreamListener, e2eUpstreamURL))) {
+		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+path.Join(e2eUpstreamListener, e2eUpstreamURL))
+		t.Logf("%v", err)
+		t.FailNow()
+		return err
+	}
+	return nil
+}
+
+func runTestAuth(t *testing.T) error {
+	// a stub OIDC provider
+	fake := newFakeAuthServer()
+	fake.location, _ = url.Parse("http://" + e2eOauthListener)
+	go func() {
+		configurationHandler := func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{
+				"issuer": "http://`+e2eOauthListener+`/auth/realms/hod-test",
+				"subject_types_supported":["public","pairwise"],
+				"id_token_signing_alg_values_supported":["ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","RS512"],
+				"userinfo_signing_alg_values_supported":["ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","RS512","none"],
+				"authorization_endpoint":"http://`+e2eOauthListener+e2eOauthAuthorizeURL+`",
+				"token_endpoint":"http://`+e2eOauthListener+e2eOauthTokenURL+`",
+				"jwks_uri":"http://`+e2eOauthListener+e2eOauthJWKSURL+`"
+			}`)
+		}
+
+		authorizeHandler := func(w http.ResponseWriter, req *http.Request) {
+			redirect := req.FormValue("redirect_uri")
+			state := req.FormValue("state")
+			code := "xyz"
+			location, _ := url.PathUnescape(redirect)
+			u, _ := url.Parse(location)
+			v := u.Query()
+			v.Set("code", code)
+			v.Set("state", state)
+			u.RawQuery = v.Encode()
+			http.Redirect(w, req, u.String(), http.StatusFound)
+		}
+
+		tokenHandler := func(w http.ResponseWriter, req *http.Request) {
+			fake.tokenHandler(w, req)
+		}
+
+		keysHandler := func(w http.ResponseWriter, req *http.Request) {
+			fake.keysHandler(w, req)
+		}
+		http.HandleFunc(e2eOauthURL, configurationHandler)
+		http.HandleFunc(e2eOauthAuthorizeURL, authorizeHandler)
+		http.HandleFunc(e2eOauthTokenURL, tokenHandler)
+		http.HandleFunc(e2eOauthJWKSURL, keysHandler)
+		_ = http.ListenAndServe(e2eOauthListener, nil)
+	}()
+	if !assert.True(t, checkListenOrBail("http://"+path.Join(e2eOauthListener, e2eOauthURL))) {
+		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+path.Join(e2eOauthListener, e2eOauthURL))
+		t.Logf("%v", err)
+		t.FailNow()
+		return err
+	}
+	return nil
+}
+
+// onRedirect forces the client to forward cookies on redirect, even though the URL is unsecure
+func onRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) > 0 {
+		for _, last := range via {
+			for _, ck := range last.Cookies() {
+				req.AddCookie(ck)
+			}
+		}
+	}
+	return nil
+}
+
+// controlledRedirect is a client RoundTripper to capture all cookies exchanged during the redirection process
+// (assuming HttpOnly is not set for testing purpose)
+type controlledRedirect struct {
+	Transport        http.RoundTripper
+	CollectedCookies map[string]*http.Cookie
+}
+
+func (c controlledRedirect) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	tr := c.Transport
+	if tr == nil {
+		tr = http.DefaultTransport
+	}
+	if c.CollectedCookies == nil {
+		c.CollectedCookies = make(map[string]*http.Cookie, 10)
+	}
+	for _, ck := range req.Cookies() {
+		c.CollectedCookies[ck.Name] = ck
+	}
+	resp, err = tr.RoundTrip(req)
+	if err != nil {
+		return
+	}
+	for _, ck := range resp.Cookies() {
+		req.AddCookie(ck)
+		c.CollectedCookies[ck.Name] = ck
+	}
+	return
+}
+
+// runTestConnect exercises a connect scenario in which the client gets redirected to
+// an OIDC authorize endpoint, then to the gatekeeper caller, and
+// eventually to a custom endpoint specified in an initial cookie.
+//
+// NOTE: in this scenario, the "state" possibly passed by the initial query
+// is no more carried on til the end of the endshake
+//
+// This scenario mimics a typical browser app running the authentication handshake
+// in an iframe, the calling a custom URL to close the iframe after successful authentication.
+//
+// NOTE: for testing purposes, we use http transport and have to force our test client to
+// forward the expected "request_uri" cookie set by the client.
+func runTestConnect(t *testing.T, config *Config) (string, []*http.Cookie, error) {
+	client := http.Client{
+		Transport: controlledRedirect{
+			CollectedCookies: make(map[string]*http.Cookie, 10),
+		},
+		CheckRedirect: onRedirect,
+	}
+	u, _ := url.Parse("http://" + e2eProxyListener + "/oauth/authorize")
+	v := u.Query()
+	v.Set("state", "my_client_nonce") // NOTE: this state provided by the client is not currently carried on to the end (lost)
+	u.RawQuery = v.Encode()
+
+	req := &http.Request{
+		Method: "GET",
+		URL:    u,
+		Header: make(http.Header),
+	}
+	// add request_uri to specify last stop redirection (inner workings since PR #440)
+	encoded := base64.StdEncoding.EncodeToString([]byte("http://" + e2eAppListener + e2eAppURL))
+	ck := &http.Cookie{
+		Name:  "request_uri",
+		Value: encoded,
+		Path:  "/",
+		// real life cookie gets Secure, SameSite
+	}
+	req.AddCookie(ck)
+
+	// attempts to login
+	resp, err := client.Do(req)
+	if !assert.NoError(t, err) {
+		return "", nil, err
+	}
+
+	// check that we get the final redirection to app correctly
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	buf, erb := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, erb)
+	assert.JSONEq(t, `{"message": "ok"}`, string(buf))
+
+	// returns all collected cookies during the handshake
+	collector := client.Transport.(controlledRedirect)
+	collected := make([]*http.Cookie, 0, 10)
+	for _, ck := range collector.CollectedCookies {
+		collected = append(collected, ck)
+	}
+
+	// assert kc-access cookie
+	var (
+		found       bool
+		accessToken string
+	)
+	for _, ck := range collected {
+		if ck.Name == config.CookieAccessName {
+			accessToken = ck.Value
+			found = true
+			break
+		}
+	}
+	assert.True(t, found)
+	if t.Failed() {
+		return "", nil, errors.New("failed to connect")
+	}
+	return accessToken, collected, nil
+}
+
+func getCookie(resp *http.Response, name string) (cookie *http.Cookie) {
+	for _, ck := range resp.Cookies() {
+		if ck.Name == name {
+			cookie = ck
+			break
+		}
+	}
+	return
+}
+
+func copyCookies(req *http.Request, cookies []*http.Cookie) {
+	ckMap := make(map[string]*http.Cookie, len(cookies))
+	for _, ck := range cookies {
+		if ck != nil {
+			ckMap[ck.Name] = ck // dedupe
+			// forward cookies obtained during authentication stage (mimicks browser)
+			req.AddCookie(ckMap[ck.Name])
+		}
+	}
+}
+
+func getUpstreamTest(t *testing.T, config *Config, cookies []*http.Cookie, expectCSRFCookie bool) (string, []*http.Cookie, error) {
+	// now exercise the ensemble with a CSRF-enabled request: this is the GET part to initialize
+	// the CSRF state with a cookie
+	client := http.Client{}
+
+	u, _ := url.Parse("http://" + e2eProxyListener + e2eUpstreamURL)
+	h := make(http.Header, 10)
+	h.Set("Content-Type", "application/json")
+	req := &http.Request{
+		Method: "GET",
+		URL:    u,
+		Header: h,
+	}
+
+	copyCookies(req, cookies)
+	resp, err := client.Do(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	buf, erb := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, erb)
+	assert.JSONEq(t, `{"message":"test"}`, string(buf)) // check this is our test resource being called
+
+	if t.Failed() {
+		return "", nil, errors.New("expected correct response body from upstream")
+	}
+
+	// now check CSRF security items
+	if !assert.NotEmpty(t, resp.Header) {
+		return "", nil, errors.New("expected some response headers")
+	}
+
+	if assert.Contains(t, resp.Header, "X-Upstream-Response-Header") { //
+		// check the returned upstream response after proxying contains headers set upstream
+		if !assert.Equal(t, []string{"test"}, resp.Header["X-Upstream-Response-Header"]) {
+			return "", nil, errors.New("expected response header set by upstream")
+		}
+	}
+
+	var csrfToken string
+	if assert.Contains(t, resp.Header, config.CSRFHeader) { // we expect a CSRF header back
+		csrfToken = resp.Header.Get(config.CSRFHeader)
+		if !assert.NotEmpty(t, csrfToken) {
+			return "", nil, errors.New("expected a non-empty CSRF token in response header")
+		}
+	} else {
+		return "", nil, errors.New("expected a CSRF token in response header")
+	}
+
+	csrfCookie := getCookie(resp, config.CSRFCookieName)
+	if expectCSRFCookie {
+		if !assert.NotNil(t, csrfCookie) {
+			return "", nil, errors.New("expected a CSRF cookie in response")
+		}
+	} else {
+		if !assert.Nil(t, csrfCookie) {
+			return "", nil, errors.New("did not expect a CSRF cookie in response")
+		}
+
+	}
+	return csrfToken, append(cookies, csrfCookie), nil
+}
+
+func getTokenTest(t *testing.T, config *Config, cookies []*http.Cookie, expectCSRFCookie bool) (string, []*http.Cookie, error) {
+	client := http.Client{}
+
+	u, _ := url.Parse("http://" + e2eProxyListener + config.OAuthURI + "/" + tokenURL)
+	h := make(http.Header, 10)
+	h.Set("Content-Type", "application/json")
+	req := &http.Request{
+		Method: "GET",
+		URL:    u,
+		Header: h,
+	}
+
+	copyCookies(req, cookies)
+	resp, err := client.Do(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	buf, erb := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, erb)
+	assert.NotEmpty(t, buf)
+
+	if t.Failed() {
+		return "", nil, errors.New("expected correct response body from upstream")
+	}
+
+	// now check CSRF security items
+	if !assert.NotEmpty(t, resp.Header) {
+		return "", nil, errors.New("expected some response headers")
+	}
+
+	var csrfToken string
+	if !assert.NotContains(t, resp.Header, config.CSRFHeader) { // we don't expect any CSRF header back
+		return "", nil, errors.New("did not expect a CSRF token in response header")
+	}
+
+	csrfCookie := getCookie(resp, config.CSRFCookieName)
+	if expectCSRFCookie {
+		if !assert.NotNil(t, csrfCookie) {
+			return "", nil, errors.New("expected a CSRF cookie in response")
+		}
+	} else {
+		if !assert.Nil(t, csrfCookie) {
+			return "", nil, errors.New("did not expect a CSRF cookie in response")
+		}
+
+	}
+	return csrfToken, append(cookies, csrfCookie), nil
+}
+
+func postUpstreamTest(t *testing.T, config *Config, cookies []*http.Cookie, csrfToken string, expectedFailure bool) (string, []*http.Cookie, error) {
+	client := http.Client{}
+
+	u, _ := url.Parse("http://" + e2eProxyListener + e2eUpstreamURL)
+	h := make(http.Header, 10)
+	h.Set("Content-Type", "application/json")
+	h.Add(config.CSRFHeader, csrfToken)
+	req := &http.Request{
+		Method: "POST",
+		URL:    u,
+		Header: h,
+	}
+
+	// resend authentication and CSRF cookies (mimic browser)
+	copyCookies(req, cookies)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	var csrfNewToken string
+	if !expectedFailure {
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		buf, erb := ioutil.ReadAll(resp.Body)
+
+		// checking response to POST
+		assert.NoError(t, erb)
+		assert.JSONEq(t, `{"message":"posted"}`, string(buf)) // check this is our test resource being called
+
+		csrfNewToken = resp.Header.Get(config.CSRFHeader)
+		assert.NotEmpty(t, csrfNewToken)
+	} else {
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		if resp.Header != nil {
+			csrfNewToken = resp.Header.Get(config.CSRFHeader)
+			assert.Empty(t, csrfNewToken)
+		}
+	}
+
+	if t.Failed() {
+		return "", nil, errors.New("error while checking POST CSRF scenario")
+	}
+	return csrfNewToken, append(cookies, getCookie(resp, config.CSRFCookieName)), nil
+}
+
+func postUpstreamWithAccessTokenTest(t *testing.T, config *Config, cookies []*http.Cookie, accessToken string) (string, []*http.Cookie, error) {
+	client := http.Client{}
+
+	u, _ := url.Parse("http://" + e2eProxyListener + e2eUpstreamURL)
+	h := make(http.Header, 10)
+	h.Set("Content-Type", "application/json")
+	h.Add("Authorization", "Bearer: "+accessToken)
+	req := &http.Request{
+		Method: "POST",
+		URL:    u,
+		Header: h,
+	}
+
+	// resend authentication and CSRF cookies (mimic browser)
+	copyCookies(req, cookies)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	var csrfNewToken string
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	buf, erb := ioutil.ReadAll(resp.Body)
+
+	// checking response to POST
+	assert.NoError(t, erb)
+	assert.JSONEq(t, `{"message":"posted"}`, string(buf)) // check this is our test resource being called
+
+	csrfNewToken = resp.Header.Get(config.CSRFHeader)
+	assert.Empty(t, csrfNewToken)
+
+	if t.Failed() {
+		return "", nil, errors.New("error while checking POST CSRF with Authorization header scenario")
+	}
+	return csrfNewToken, append(cookies, getCookie(resp, config.CSRFCookieName)), nil
+}
+
+func postUpstream2Test(t *testing.T, config *Config, cookies []*http.Cookie) (string, []*http.Cookie, error) {
+	client := http.Client{}
+
+	u, _ := url.Parse("http://" + e2eProxyListener + e2eUpstreamURL2)
+	h := make(http.Header, 10)
+	h.Set("Content-Type", "application/json")
+	req := &http.Request{
+		Method: "POST",
+		URL:    u,
+		Header: h,
+	}
+
+	// resend authentication and CSRF cookies (mimic browser)
+	copyCookies(req, cookies)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	var csrfNewToken string
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	buf, erb := ioutil.ReadAll(resp.Body)
+
+	// checking response to POST
+	assert.NoError(t, erb)
+	assert.JSONEq(t, `{"message":"posted"}`, string(buf)) // check this is our test resource being called
+
+	csrfNewToken = resp.Header.Get(config.CSRFHeader)
+	assert.Empty(t, csrfNewToken)
+
+	if t.Failed() {
+		return "", nil, errors.New("error while checking POST NO CSRF scenario")
+	}
+	return csrfNewToken, append(cookies, getCookie(resp, config.CSRFCookieName)), nil
+}
+
+func TestCSRF(t *testing.T) {
+	//log.SetOutput(ioutil.Discard)
+	config := newDefaultConfig()
+	config.Verbose = false
+	config.DisableAllLogging = true
+	config.EnableLogging = false
+
+	config.Listen = e2eProxyListener
+	config.DiscoveryURL = "http://" + e2eOauthListener + e2eOauthURL
+	config.Upstream = "http://" + e2eUpstreamListener
+
+	config.CorsOrigins = []string{"*"}
+	config.EnableCSRF = true
+	config.HTTPOnlyCookie = false // since we want to inspect the cookie for testing
+	config.SecureCookie = false   // since we are testing over HTTP
+	config.AccessTokenDuration = 30 * time.Minute
+	config.EnableEncryptedToken = false
+	config.EnableSessionCookies = true
+	config.EnableAuthorizationCookies = false
+	config.ClientID = fakeClientID
+	config.ClientSecret = fakeSecret
+	config.Resources = []*Resource{
+		{
+			URL:         e2eUpstreamURL2,
+			Methods:     []string{"GET", "POST", "DELETE"},
+			WhiteListed: false,
+			EnableCSRF:  false,
+		},
+	}
+	assert.Error(t, config.isValid())
+
+	config.EncryptionKey = "01234567890123456789012345678901"
+	assert.Error(t, config.isValid())
+
+	config.Resources = append(config.Resources, &Resource{
+		URL:         e2eUpstreamURL,
+		Methods:     []string{"GET", "POST", "DELETE"},
+		WhiteListed: false,
+		EnableCSRF:  true,
+	})
+	assert.NoError(t, config.isValid())
+
+	// launch fake upstream resource server
+	err := runTestUpstream(t)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	// launch fake app server where to land after authentication
+	err = runTestApp(t)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	// launch fake oauth OIDC server
+	err = runTestAuth(t)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	// launch keycloak-gatekeeper proxy
+	err = runTestGatekeeper(t, config)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	// establish an authenticated session
+	accessToken, cookies, err := runTestConnect(t, config)
+	if !assert.NoError(t, err) {
+		t.Logf("could not login: %v", err)
+		t.FailNow()
+	}
+	var found bool
+	for _, ck := range cookies {
+		if ck.Name == config.CSRFCookieName {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found)
+
+	// initialize state: access CSRF protected endpoint with a GET request
+	//   - call upstream with proper cookies and expect a CSRF token token back
+	csrfToken, newCookies, err := getUpstreamTest(t, config, cookies, false)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on GET upstream test: %v", err)
+		t.FailNow()
+	}
+	assert.NotEmpty(t, csrfToken)
+	t.Logf("CSRF test on state initialization passed")
+
+	// Scenario 1: call protected resource, with CSRF state ready
+	//   - calls upstream with a properly authenticated POST, adding the expected CSRF header
+	csrfNewToken, newCookies, err := postUpstreamTest(t, config, newCookies, csrfToken, false)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on POST upstream scenario 1: %v", err)
+		t.FailNow()
+	}
+	assert.NotEqual(t, csrfToken, csrfNewToken)
+	t.Logf("CSRF test on POST upstream scenario 1 passed")
+
+	// Scenario 2: POST again with the newly returned header
+	//   - calls upstream with a properly authenticated POST, adding the init CSRF header, with latest received CSRF header
+	_, newCookies, err = postUpstreamTest(t, config, newCookies, csrfNewToken, false)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on POST upstream scenario 1: %v", err)
+		t.FailNow()
+	}
+	t.Logf("CSRF test on POST upstream scenario 2 passed")
+
+	// Scenario 3: replaying an older valid token on POST, within the same session
+	// This illustrates the generation of one-time in-the-clear header token remaining valid for the session
+	// (allows multiple tabs usage).
+	//
+	//   - calls upstream with a properly authenticated POST, adding the init CSRF header, with some older CSRF header
+	//     retrieved during the session
+	_, newCookies, err = postUpstreamTest(t, config, newCookies, csrfToken, false)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on POST upstream scenario 3: %v", err)
+		t.FailNow()
+	}
+	t.Logf("CSRF test on POST upstream scenario 3 passed")
+
+	// Scenario 4: POST with an invalid token
+	_, newCookies, err = postUpstreamTest(t, config, newCookies, "fake-token", true)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on POST upstream scenario 4: %v", err)
+		t.FailNow()
+	}
+	t.Logf("CSRF test on POST upstream scenario 4 passed")
+
+	// Scenario 5: POST without CSRF token header, but with a Authorization Bearer header
+	_, newCookies, err = postUpstreamWithAccessTokenTest(t, config, newCookies, accessToken)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on POST upstream scenario 5: %v", err)
+		t.FailNow()
+	}
+	t.Logf("CSRF test on POST upstream scenario 5 passed")
+
+	// Scenario 6: POST without CSRF token header, on resource with disabled CSRF
+	_, newCookies, err = postUpstream2Test(t, config, newCookies)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on POST upstream scenario 6: %v", err)
+		t.FailNow()
+	}
+	t.Logf("CSRF test on POST upstream scenario 6 passed")
+
+	// Scenario 7: check if CSRF state changes with new GET
+	//   - cookie is already there and (normally) not expired: not sent back
+	csrfNewToken, _, err = getUpstreamTest(t, config, newCookies, false)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on GET upstream test scenario 7: %v", err)
+		t.FailNow()
+	}
+
+	_, _, err = postUpstreamTest(t, config, newCookies, csrfNewToken, false)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on POST upstream scenario 7: %v", err)
+		t.FailNow()
+	}
+	t.Logf("CSRF test on POST upstream scenario 7 passed")
+
+	// Scenario 8: admin endpoints yield a CSRF token in header
+	// only if the Deny middleware did the job. Endpoints such as /auth/token don't deliver
+	// CSRF header back.
+	// (use-case: init CSRF state before calling APIs, when first call is a POST/PUT/DELETE...)
+	_, _, err = getTokenTest(t, config, newCookies, false)
+	if !assert.NoError(t, err) {
+		t.Logf("CSRF test failed on GET upstream test scenario 8: %v", err)
+		t.FailNow()
+	}
+	t.Logf("CSRF test on POST upstream scenario 8 passed")
+}

--- a/doc.go
+++ b/doc.go
@@ -147,6 +147,8 @@ type Resource struct {
 	Roles []string `json:"roles" yaml:"roles"`
 	// Groups is a list of groups the user is in
 	Groups []string `json:"groups" yaml:"groups"`
+	// EnableCSRF enables CSRF check on this upstream Resource
+	EnableCSRF bool `json:"enable-csrf" yaml:"enable-csrf"`
 }
 
 // Config is the configuration for the proxy
@@ -192,7 +194,7 @@ type Config struct {
 	// RequestIDHeader is the header name for request ids
 	RequestIDHeader string `json:"request-id-header" yaml:"request-id-header" usage:"the http header name for request id" env:"REQUEST_ID_HEADER"`
 	// ResponseHeader is a map of response headers to add to the response
-	ResponseHeaders map[string]string `json:"response-headers" yaml:"response-headers" usage:"custom headers to added to the http response key=value"`
+	ResponseHeaders map[string]string `json:"response-headers" yaml:"response-headers" usage:"custom headers to be added to the http response key=value"`
 
 	// EnableSelfSignedTLS indicates we should create a self-signed ceritificate for the service
 	EnabledSelfSignedTLS bool `json:"enable-self-signed-tls" yaml:"enable-self-signed-tls" usage:"create self signed certificates for the proxy" env:"ENABLE_SELF_SIGNED_TLS"`
@@ -215,12 +217,20 @@ type Config struct {
 	EnableJSONLogging bool `json:"enable-json-logging" yaml:"enable-json-logging" usage:"switch on json logging rather than text"`
 	// EnableForwarding enables the forwarding proxy
 	EnableForwarding bool `json:"enable-forwarding" yaml:"enable-forwarding" usage:"enables the forwarding proxy mode, signing outbound request"`
-	// EnableSecurityFilter enabled the security handler
+	// EnableSecurityFilter enables the security handler
 	EnableSecurityFilter bool `json:"enable-security-filter" yaml:"enable-security-filter" usage:"enables the security filter handler" env:"ENABLE_SECURITY_FILTER"`
 	// EnableRefreshTokens indicate's you wish to ignore using refresh tokens and re-auth on expiration of access token
 	EnableRefreshTokens bool `json:"enable-refresh-tokens" yaml:"enable-refresh-tokens" usage:"enables the handling of the refresh tokens" env:"ENABLE_REFRESH_TOKEN"`
 	// EnableSessionCookies indicates the cookies, both token and refresh should not be persisted
 	EnableSessionCookies bool `json:"enable-session-cookies" yaml:"enable-session-cookies" usage:"access and refresh tokens are session only i.e. removed browser close"`
+	// EnableCSRF will generate a new session object (e.g.a cookie, or in a supported backend storage) to store a CSRF token.
+	// To enable CSRF on upstream endpoints, an additional EnableCSRF is needed in the Resource config section.
+	EnableCSRF bool `json:"enable-csrf" yaml:"enable-csrf" usage:"when enabled, this automatically adds a CSRF token to all responses. Matching token expected for next request is stored in the session (e.g. cookie or storage)" env:"ENABLE_CSRF"`
+	// CSRFCookieName sets the name of the CSRF (encrypted) cookie, when session storage is a cookie (defaults to kc-csrf).
+	// Note that in this case EncryptionKey is required to encrypt the cookie.
+	CSRFCookieName string `json:"csrf-cookie-name" yaml:"csrf-cookie-name" usage:"the name of CSRF cookie. Defaults to: kc-csrf" env:"CSRF_COOKIE_NAME"`
+	// CSRFHeader sets the header used in requests and response for the CSRF challenge (defaults to X-CSRF-Token)
+	CSRFHeader string `json:"csrf-header" yaml:"csrf-header" usage:"the header added to responses by gatekeeper and to be added by requests to check against replayed credentials (CSRF). Defaults to: X-CSRF-Token" env:"CSRF_HEADER"`
 	// EnableLoginHandler indicates we want the login handler enabled
 	EnableLoginHandler bool `json:"enable-login-handler" yaml:"enable-login-handler" usage:"enables the handling of the refresh tokens" env:"ENABLE_LOGIN_HANDLER"`
 	// EnableTokenHeader adds the JWT token to the upstream authentication headers
@@ -288,7 +298,8 @@ type Config struct {
 	// CorsCredentials set the credentials flag
 	CorsCredentials bool `json:"cors-credentials" yaml:"cors-credentials" usage:"credentials access control header (Access-Control-Allow-Credentials)"`
 	// CorsMaxAge is the age for CORS
-	CorsMaxAge time.Duration `json:"cors-max-age" yaml:"cors-max-age" usage:"max age applied to cors headers (Access-Control-Max-Age)"`
+	CorsMaxAge          time.Duration `json:"cors-max-age" yaml:"cors-max-age" usage:"max age applied to cors headers (Access-Control-Max-Age)"`
+	CorsDisableUpstream bool          `json:"cors-disable-upstream" yaml:"cors-disable-upstream" usage:"do not extend CORS support to upstream responses: only gatekeeper endpoints are CORS-enabled"`
 
 	// Hostnames is a list of hostname's the service should response to
 	Hostnames []string `json:"hostnames" yaml:"hostnames" usage:"list of hostnames the service will respond to"`

--- a/forwarding.go
+++ b/forwarding.go
@@ -49,6 +49,14 @@ func (r *oauthProxy) proxyMiddleware(next http.Handler) http.Handler {
 			req.Header.Set(k, v)
 		}
 
+		if r.config.EnableCSRF {
+			// remove csrf header
+			req.Header.Del(r.config.CSRFHeader)
+			if !r.config.EnableAuthorizationCookies {
+				_ = filterCookies(req, []string{r.config.CSRFCookieName})
+			}
+		}
+
 		// @note: by default goproxy only provides a forwarding proxy, thus all requests have to be absolute and we must update the host headers
 		req.URL.Host = r.endpoint.Host
 		req.URL.Scheme = r.endpoint.Scheme

--- a/misc.go
+++ b/misc.go
@@ -100,9 +100,9 @@ func (r *oauthProxy) redirectToAuthorization(w http.ResponseWriter, req *http.Re
 	uuid := r.writeStateParameterCookie(req, w)
 	authQuery := fmt.Sprintf("?state=%s", uuid)
 
-	// step: if verification is switched off, we can't authorization
+	// step: if verification is switched off, we can't authorize
 	if r.config.SkipTokenVerification {
-		r.log.Error("refusing to redirection to authorization endpoint, skip token verification switched on")
+		r.log.Error("refusing to redirect to authorization endpoint, skip token verification switched on")
 		w.WriteHeader(http.StatusForbidden)
 		return r.revokeProxy(w, req)
 	}

--- a/server.go
+++ b/server.go
@@ -60,6 +60,7 @@ type oauthProxy struct {
 	store          storage
 	templates      *template.Template
 	upstream       reverseProxy
+	csrf           func(http.Handler) http.Handler
 }
 
 func init() {
@@ -195,8 +196,14 @@ func (r *oauthProxy) createReverseProxy() error {
 		engine.Use(r.responseHeaderMiddleware(r.config.ResponseHeaders))
 	}
 
+	// configure CSRF middleware
+	r.csrf = r.csrfConfigMiddleware()
+
 	// step: add the routing for oauth
-	engine.With(proxyDenyMiddleware).Route(r.config.OAuthURI, func(e chi.Router) {
+	engine.With(proxyDenyMiddleware,
+		r.csrfSkipMiddleware(), // handle CSRF state, but skip check on POST endpoints below
+		r.csrfProtectMiddleware(),
+		r.csrfHeaderMiddleware()).Route(r.config.OAuthURI, func(e chi.Router) {
 		e.MethodNotAllowed(methodNotAllowHandlder)
 		e.HandleFunc(authorizationURL, r.oauthAuthorizationHandler)
 		e.Get(callbackURL, r.oauthCallbackHandler)
@@ -260,8 +267,10 @@ func (r *oauthProxy) createReverseProxy() error {
 		e := engine.With(
 			r.authenticationMiddleware(x),
 			r.admissionMiddleware(x),
-			r.identityHeadersMiddleware(r.config.AddClaims))
-
+			r.identityHeadersMiddleware(r.config.AddClaims),
+			r.csrfSkipResourceMiddleware(x),
+			r.csrfProtectMiddleware(),
+			r.csrfHeaderMiddleware())
 		for _, m := range x.Methods {
 			if !x.WhiteListed {
 				e.MethodFunc(m, x.URL, emptyHandler)
@@ -605,6 +614,7 @@ func (r *oauthProxy) createUpstreamProxy(upstream *url.URL) error {
 	// create the forwarding proxy
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Logger = httplog.New(ioutil.Discard, "", 0)
+	proxy.KeepDestinationHeaders = !r.config.CorsDisableUpstream
 	r.upstream = proxy
 
 	// update the tls configuration of the reverse proxy


### PR DESCRIPTION
This adds an automatic CSRF capability to protect cookies-authenticated client against replay attacks.

* enables automatic CRSF check on POST,PUT,DELETE,PATCH methods upstream
* enabled/disabled on a per resource basis
* defines new encrypted cookie to store CSRF state
* client must add CSRF token in header for requests, to supplement access cookie
* uses github.com/gorilla/csrf

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>