### PR TITLE
[KEYCLOAK-9452] redirections should instruct browser to disable caching

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -84,6 +84,7 @@ func (r *oauthProxy) accessForbidden(w http.ResponseWriter, req *http.Request) c
 
 // redirectToURL redirects the user and aborts the context
 func (r *oauthProxy) redirectToURL(url string, w http.ResponseWriter, req *http.Request, statusCode int) context.Context {
+	w.Header().Add("Cache-Control", "nocache, no-store, must-revalidate, max-age=0")
 	http.Redirect(w, req, url, statusCode)
 
 	return r.revokeProxy(w, req)

--- a/misc.go
+++ b/misc.go
@@ -84,7 +84,7 @@ func (r *oauthProxy) accessForbidden(w http.ResponseWriter, req *http.Request) c
 
 // redirectToURL redirects the user and aborts the context
 func (r *oauthProxy) redirectToURL(url string, w http.ResponseWriter, req *http.Request, statusCode int) context.Context {
-	w.Header().Add("Cache-Control", "nocache, no-store, must-revalidate, max-age=0")
+	w.Header().Add("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 	http.Redirect(w, req, url, statusCode)
 
 	return r.revokeProxy(w, req)


### PR DESCRIPTION
Gatekeeper may respond with redirections, and browsers may cache the target URL.
This may cause some issues with browsers.

Gatekeeper should instruct browsers to disable caching redirected URLs, with
a Cache-Control header set to: 'nocache, no-store, must-revalidate, max-age=0'.

This would be in line with keycloak's redirection responses.

I tested this on the authorize workflow, but I assume this should be true for all redirections initiated by gatekeeper.

 ### Reproducing
> When logging in several times, some browsers may cache the initial redirected URL (tested with firefox 64.0 on linux, browser app chains logins skipping logout): on the second login, the browser skips the call to gatekeeper and directly calls the cached target URL.