### PR TITLE
Add ability to proxy to an upstream sub path

### DIFF
--- a/forwarding.go
+++ b/forwarding.go
@@ -52,6 +52,9 @@ func (r *oauthProxy) proxyMiddleware(next http.Handler) http.Handler {
 		// @note: by default goproxy only provides a forwarding proxy, thus all requests have to be absolute and we must update the host headers
 		req.URL.Host = r.endpoint.Host
 		req.URL.Scheme = r.endpoint.Scheme
+		if r.endpoint.Path != "" {
+			req.URL.Path = r.endpoint.Path + req.URL.Path
+		}
 		if v := req.Header.Get("Host"); v != "" {
 			req.Host = v
 			req.Header.Del("Host")


### PR DESCRIPTION
This allows to configure an upstream url with a path like `http://example.com/foo` and requests to `/bar` will be proxied to `http://example.com/foo/bar`.