### PR TITLE
[KEYCLOAK-9086] Add .golangci.yml config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 60
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+
+linters:
+  enable-all: true
+  disable:
+    - maligned
+    - unparam
+    - lll
+    - gochecknoinits
+    - gochecknoglobals


### PR DESCRIPTION
This allows this repo (or its forks) to be configured for golangCI linting platform.

This also provide settings for local golangci-lint tool. See also PR #448.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>