### PR TITLE
Keep the response headers already set to the response before the upstream request

### DIFF
--- a/server.go
+++ b/server.go
@@ -157,6 +157,8 @@ func (r *oauthProxy) createReverseProxy() error {
 	if err := r.createUpstreamProxy(r.endpoint); err != nil {
 		return err
 	}
+	// keep the destination headers to eventually preserve the refreshed access token cookie in the response
+	r.upstream.(*goproxy.ProxyHttpServer).KeepDestinationHeaders = true
 	engine := chi.NewRouter()
 	engine.MethodNotAllowed(emptyHandler)
 	engine.NotFound(emptyHandler)

--- a/server_test.go
+++ b/server_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/jose"
+	"github.com/elazarl/goproxy"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,6 +75,7 @@ func TestNewKeycloakProxy(t *testing.T) {
 	proxy, err := newProxy(cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, proxy)
+	assert.True(t, proxy.upstream.(*goproxy.ProxyHttpServer).KeepDestinationHeaders)
 	assert.NotNil(t, proxy.config)
 	assert.NotNil(t, proxy.router)
 	assert.NotNil(t, proxy.endpoint)


### PR DESCRIPTION
Enable the KeepDestinationHeaders flag of the upstream proxy to preserve the headers already set in the response before the request to the upstream server.

Concerned headers are the set-cookie header holding the refreshed access_token and the headers set with the --response-headers flag