### PR TITLE
[KEYCLOAK-9703] Add client auth method option to gatekeeper config

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,6 +35,7 @@ func newDefaultConfig() *Config {
 
 	return &Config{
 		AccessTokenDuration:           time.Duration(720) * time.Hour,
+		ClientAuthMethod:              authMethodBasic,
 		CookieAccessName:              accessCookie,
 		CookieRefreshName:             refreshCookie,
 		EnableAuthorizationCookies:    true,
@@ -188,6 +189,9 @@ func (r *Config) isValid() error {
 				if _, err := url.Parse(r.StoreURL); err != nil {
 					return fmt.Errorf("the store url is invalid, error: %s", err)
 				}
+			}
+			if r.ClientAuthMethod != authMethodBasic && r.ClientAuthMethod != authMethodBody {
+				return fmt.Errorf("invalid client auth method %q (valid values: %s, %s)", r.ClientAuthMethod, authMethodBasic, authMethodBody)
 			}
 		}
 		// check: ensure each of the resource are valid

--- a/config_test.go
+++ b/config_test.go
@@ -35,39 +35,44 @@ func TestIsConfig(t *testing.T) {
 		},
 		{
 			Config: &Config{
-				DiscoveryURL: "http://127.0.0.1:8080",
+				DiscoveryURL:     "http://127.0.0.1:8080",
+				ClientAuthMethod: "secret-basic",
 			},
 		},
 		{
 			Config: &Config{
-				DiscoveryURL: "http://127.0.0.1:8080",
-				ClientID:     "client",
-				ClientSecret: "client",
+				DiscoveryURL:     "http://127.0.0.1:8080",
+				ClientAuthMethod: "secret-basic",
+				ClientID:         "client",
+				ClientSecret:     "client",
 			},
 		},
 		{
 			Config: &Config{
-				Listen:         ":8080",
-				DiscoveryURL:   "http://127.0.0.1:8080",
-				ClientID:       "client",
-				ClientSecret:   "client",
-				RedirectionURL: "http://120.0.0.1",
+				Listen:           ":8080",
+				DiscoveryURL:     "http://127.0.0.1:8080",
+				ClientAuthMethod: "secret-basic",
+				ClientID:         "client",
+				ClientSecret:     "client",
+				RedirectionURL:   "http://120.0.0.1",
 			},
 		},
 		{
 			Config: &Config{
-				Listen:         ":8080",
-				DiscoveryURL:   "http://127.0.0.1:8080",
-				ClientID:       "client",
-				ClientSecret:   "client",
-				RedirectionURL: "http://120.0.0.1",
-				Upstream:       "http://120.0.0.1",
+				Listen:           ":8080",
+				DiscoveryURL:     "http://127.0.0.1:8080",
+				ClientAuthMethod: "secret-basic",
+				ClientID:         "client",
+				ClientSecret:     "client",
+				RedirectionURL:   "http://120.0.0.1",
+				Upstream:         "http://120.0.0.1",
 			},
 		},
 		{
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				ClientAuthMethod:    "secret-basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -81,6 +86,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				ClientAuthMethod:    "secret-basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -93,6 +99,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				ClientAuthMethod:    "secret-basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -103,12 +110,13 @@ func TestIsConfig(t *testing.T) {
 		},
 		{
 			Config: &Config{
-				Listen:         ":8080",
-				DiscoveryURL:   "http://127.0.0.1:8080",
-				ClientID:       "client",
-				ClientSecret:   "client",
-				RedirectionURL: "http://120.0.0.1",
-				Upstream:       "http://120.0.0.1",
+				Listen:           ":8080",
+				DiscoveryURL:     "http://127.0.0.1:8080",
+				ClientAuthMethod: "secret-basic",
+				ClientID:         "client",
+				ClientSecret:     "client",
+				RedirectionURL:   "http://120.0.0.1",
+				Upstream:         "http://120.0.0.1",
 				MatchClaims: map[string]string{
 					"test": "&&&[",
 				},
@@ -129,6 +137,7 @@ func TestIsConfig(t *testing.T) {
 		{
 			Config: &Config{
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				ClientAuthMethod:    "secret-basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -141,6 +150,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				ClientAuthMethod:    "secret-basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -152,6 +162,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				ClientAuthMethod:    "secret-basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -164,6 +175,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				ClientAuthMethod:    "secret-basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "http://120.0.0.1",
@@ -177,6 +189,7 @@ func TestIsConfig(t *testing.T) {
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
+				ClientAuthMethod:    "secret-basic",
 				ClientID:            "client",
 				ClientSecret:        "client",
 				RedirectionURL:      "https://120.0.0.1",

--- a/doc.go
+++ b/doc.go
@@ -70,6 +70,8 @@ const (
 	unsecureScheme     = "http"
 	secureScheme       = "https"
 	anyMethod          = "ANY"
+	authMethodBasic    = "secret-basic"
+	authMethodBody     = "secret-body"
 
 	_ contextKey = iota
 	contextScopeName
@@ -248,6 +250,8 @@ type Config struct {
 
 	// AccessTokenDuration is default duration applied to the access token cookie
 	AccessTokenDuration time.Duration `json:"access-token-duration" yaml:"access-token-duration" usage:"fallback cookie duration for the access token when using refresh tokens"`
+	// ClientAuthMethod defines the method for authenticating the oauth client to the server
+	ClientAuthMethod string `json:"client-auth-method" yaml:"client-auth-method" usage:"the auth method to use with oauth (secret-basic, secret-body)" env:"CLIENT_AUTH_METHOD"`
 	// CookieDomain is a list of domains the cookie is available to
 	CookieDomain string `json:"cookie-domain" yaml:"cookie-domain" usage:"domain the access cookie is available to, defaults host header"`
 	// CookieAccessName is the name of the access cookie holding the access token

--- a/oauth.go
+++ b/oauth.go
@@ -30,13 +30,13 @@ import (
 )
 
 // getOAuthClient returns a oauth2 client from the openid client
-func (r *oauthProxy) getOAuthClient(redirectionURL string) (*oauth2.Client, error) {
+func (r *oauthProxy) getOAuthClient(redirectionURL string, clientAuthMethod string) (*oauth2.Client, error) {
 	return oauth2.NewClient(r.idpClient, oauth2.Config{
 		Credentials: oauth2.ClientCredentials{
 			ID:     r.config.ClientID,
 			Secret: r.config.ClientSecret,
 		},
-		AuthMethod:  oauth2.AuthMethodClientSecretBasic,
+		AuthMethod:  clientAuthMethod,
 		AuthURL:     r.idp.AuthEndpoint.String(),
 		RedirectURL: redirectionURL,
 		Scope:       append(r.config.Scopes, oidc.DefaultScope...),


### PR DESCRIPTION
Gatekeeper is still uses go-oidc v1, which makes Gatekeeper to send
auth-code to exchange for access token at server's token endpoint
with both client-authentication methods: basic and post.

As soon as Gatekeeper gets an upgrade to go-oidc v2 this commit no
longer will be necessary.

Co-authored-by: Samuel Lang <gh@lang-sam.de>