### PR TITLE
[KEYCLOAK-9870] Fix refresh token issue

### DIFF
--- a/forwarding.go
+++ b/forwarding.go
@@ -150,7 +150,7 @@ func (r *oauthProxy) forwardProxyHandler() func(*http.Request, *http.Response) {
 						zap.String("expires", state.expiration.Format(time.RFC3339)))
 
 					// step: attempt to refresh the access
-					token, expiration, err := getRefreshedToken(r.client, state.refresh)
+					token, newRefreshToken, expiration, _, err := getRefreshedToken(r.client, state.refresh)
 					if err != nil {
 						state.login = true
 						switch err {
@@ -169,6 +169,9 @@ func (r *oauthProxy) forwardProxyHandler() func(*http.Request, *http.Response) {
 					state.expiration = expiration
 					state.wait = true
 					state.login = false
+					if newRefreshToken != "" {
+						state.refresh = newRefreshToken
+					}
 
 					// step: add some debugging
 					r.log.Info("successfully refreshed the access token",
@@ -193,7 +196,7 @@ func (r *oauthProxy) forwardProxyHandler() func(*http.Request, *http.Response) {
 				duration := getWithin(state.expiration, 0.85)
 				r.log.Info("waiting for expiration of access token",
 					zap.String("token_expiration", state.expiration.Format(time.RFC3339)),
-					zap.String("renewel_duration", duration.String()))
+					zap.String("renewal_duration", duration.String()))
 
 				<-time.After(duration)
 			}

--- a/handlers.go
+++ b/handlers.go
@@ -489,7 +489,7 @@ func (r *oauthProxy) proxyMetricsHandler(w http.ResponseWriter, req *http.Reques
 }
 
 // retrieveRefreshToken retrieves the refresh token from store or cookie
-func (r *oauthProxy) retrieveRefreshToken(req *http.Request, user *userContext) (token, ecrypted string, err error) {
+func (r *oauthProxy) retrieveRefreshToken(req *http.Request, user *userContext) (token, encrypted string, err error) {
 	switch r.useStore() {
 	case true:
 		token, err = r.GetRefreshToken(user.token)
@@ -500,7 +500,7 @@ func (r *oauthProxy) retrieveRefreshToken(req *http.Request, user *userContext) 
 		return
 	}
 
-	ecrypted = token // returns encryped, avoid encoding twice
+	encrypted = token // returns encrypted, avoids encoding twice
 	token, err = decodeText(token, r.config.EncryptionKey)
 	return
 }

--- a/middleware.go
+++ b/middleware.go
@@ -167,8 +167,15 @@ func (r *oauthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 						return
 					}
 
-					// attempt to refresh the access token
-					token, exp, err := getRefreshedToken(r.client, refresh)
+					// attempt to refresh the access token, possibly with a renewed refresh token
+					//
+					// NOTE: atm, this does not retrieve explicit refresh token expiry from oauth2,
+					// and take identity expiry instead: with keycloak, they are the same and equal to
+					// "SSO session idle" keycloak setting.
+					//
+					// exp: expiration of the access token
+					// expiresIn: expiration of the ID token
+					token, newRefreshToken, accessExpiresAt, refreshExpiresIn, err := getRefreshedToken(r.client, refresh)
 					if err != nil {
 						switch err {
 						case ErrRefreshTokenExpired:
@@ -184,14 +191,24 @@ func (r *oauthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 
 						return
 					}
-					// get the expiration of the new access token
-					expiresIn := r.getAccessCookieExpiration(token, refresh)
+
+					accessExpiresIn := time.Until(accessExpiresAt)
+
+					// get the expiration of the new refresh token
+					if newRefreshToken != "" {
+						refresh = newRefreshToken
+					}
+					if refreshExpiresIn == 0 {
+						// refresh token expiry claims not available: try to parse refresh token
+						refreshExpiresIn = r.getAccessCookieExpiration(token, refresh)
+					}
 
 					r.log.Info("injecting the refreshed access token cookie",
 						zap.String("client_ip", clientIP),
 						zap.String("cookie_name", r.config.CookieAccessName),
 						zap.String("email", user.email),
-						zap.Duration("expires_in", time.Until(exp)))
+						zap.Duration("refresh_expires_in", refreshExpiresIn),
+						zap.Duration("expires_in", accessExpiresIn))
 
 					accessToken := token.Encode()
 					if r.config.EnableEncryptedToken {
@@ -202,7 +219,20 @@ func (r *oauthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 						}
 					}
 					// step: inject the refreshed access token
-					r.dropAccessTokenCookie(req.WithContext(ctx), w, accessToken, expiresIn)
+					r.dropAccessTokenCookie(req.WithContext(ctx), w, accessToken, accessExpiresIn)
+
+					// step: inject the renewed refresh token
+					if newRefreshToken != "" {
+						r.log.Debug("renew refresh cookie with new refresh token",
+							zap.Duration("refresh_expires_in", refreshExpiresIn))
+						encryptedRefreshToken, err := encodeText(newRefreshToken, r.config.EncryptionKey)
+						if err != nil {
+							r.log.Error("failed to encrypt the refresh token", zap.Error(err))
+							w.WriteHeader(http.StatusInternalServerError)
+							return
+						}
+						r.dropRefreshTokenCookie(req.WithContext(ctx), w, encryptedRefreshToken, refreshExpiresIn)
+					}
 
 					if r.useStore() {
 						go func(old, new jose.JWT, encrypted string) {

--- a/misc.go
+++ b/misc.go
@@ -115,10 +115,10 @@ func (r *oauthProxy) redirectToAuthorization(w http.ResponseWriter, req *http.Re
 	return r.revokeProxy(w, req)
 }
 
-// getAccessCookieExpiration calucates the expiration of the access token cookie
+// getAccessCookieExpiration calculates the expiration of the access token cookie
 func (r *oauthProxy) getAccessCookieExpiration(token jose.JWT, refresh string) time.Duration {
 	// notes: by default the duration of the access token will be the configuration option, if
-	// however we can decode the refresh token, we will set the duration to the duraction of the
+	// however we can decode the refresh token, we will set the duration to the duration of the
 	// refresh token
 	duration := r.config.AccessTokenDuration
 	if _, ident, err := parseToken(refresh); err == nil {
@@ -126,6 +126,9 @@ func (r *oauthProxy) getAccessCookieExpiration(token jose.JWT, refresh string) t
 		if delta > 0 {
 			duration = delta
 		}
+		r.log.Debug("parsed refresh token with new duration", zap.Duration("new duration", delta))
+	} else {
+		r.log.Debug("refresh token is opaque and cannot be used to extend calculated duration")
 	}
 
 	return duration


### PR DESCRIPTION
Whenever keycloak is set to revoke refresh tokens after usage, we need to get
the new refresh token, its expiry and refresh the cookie in response.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>