### PR TITLE
[KEYCLOAK-10668] Do not set the cookie domain

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -28,7 +28,7 @@ import (
 // dropCookie drops a cookie into the response
 func (r *oauthProxy) dropCookie(w http.ResponseWriter, host, name, value string, duration time.Duration) {
 	// step: default to the host header, else the config domain
-	domain := strings.Split(host, ":")[0]
+	domain := ""
 	if r.config.CookieDomain != "" {
 		domain = r.config.CookieDomain
 	}

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -37,7 +37,7 @@ func TestCookieDomainHostHeader(t *testing.T) {
 		}
 	}
 	assert.NotNil(t, cookie)
-	assert.Equal(t, cookie.Domain, "127.0.0.1")
+	assert.Equal(t, cookie.Domain, "")
 }
 
 func TestCookieBasePath(t *testing.T) {
@@ -104,7 +104,7 @@ func TestDropCookie(t *testing.T) {
 	p.dropCookie(resp, req.Host, "test-cookie", "test-value", 0)
 
 	assert.Equal(t, resp.Header().Get("Set-Cookie"),
-		"test-cookie=test-value; Path=/; Domain=127.0.0.1",
+		"test-cookie=test-value; Path=/",
 		"we have not set the cookie, headers: %v", resp.Header())
 
 	req = newFakeHTTPRequest("GET", "/admin")
@@ -113,7 +113,7 @@ func TestDropCookie(t *testing.T) {
 	p.dropCookie(resp, req.Host, "test-cookie", "test-value", 0)
 
 	assert.Equal(t, resp.Header().Get("Set-Cookie"),
-		"test-cookie=test-value; Path=/; Domain=127.0.0.1",
+		"test-cookie=test-value; Path=/",
 		"we have not set the cookie, headers: %v", resp.Header())
 
 	req = newFakeHTTPRequest("GET", "/admin")
@@ -140,7 +140,7 @@ func TestDropRefreshCookie(t *testing.T) {
 	p.dropRefreshTokenCookie(req, resp, "test", 0)
 
 	assert.Equal(t, resp.Header().Get("Set-Cookie"),
-		refreshCookie+"=test; Path=/; Domain=127.0.0.1",
+		refreshCookie+"=test; Path=/",
 		"we have not set the cookie, headers: %v", resp.Header())
 }
 
@@ -153,7 +153,7 @@ func TestSessionOnlyCookie(t *testing.T) {
 	p.dropCookie(resp, req.Host, "test-cookie", "test-value", 1*time.Hour)
 
 	assert.Equal(t, resp.Header().Get("Set-Cookie"),
-		"test-cookie=test-value; Path=/; Domain=127.0.0.1",
+		"test-cookie=test-value; Path=/",
 		"we have not set the cookie, headers: %v", resp.Header())
 }
 
@@ -165,7 +165,7 @@ func TestHTTPOnlyCookie(t *testing.T) {
 	p.dropCookie(resp, req.Host, "test-cookie", "test-value", 0)
 
 	assert.Equal(t, resp.Header().Get("Set-Cookie"),
-		"test-cookie=test-value; Path=/; Domain=127.0.0.1",
+		"test-cookie=test-value; Path=/",
 		"we have not set the cookie, headers: %v", resp.Header())
 
 	req = newFakeHTTPRequest("GET", "/admin")
@@ -174,7 +174,7 @@ func TestHTTPOnlyCookie(t *testing.T) {
 	p.dropCookie(resp, req.Host, "test-cookie", "test-value", 0)
 
 	assert.Equal(t, resp.Header().Get("Set-Cookie"),
-		"test-cookie=test-value; Path=/; Domain=127.0.0.1; HttpOnly",
+		"test-cookie=test-value; Path=/; HttpOnly",
 		"we have not set the cookie, headers: %v", resp.Header())
 }
 
@@ -185,7 +185,7 @@ func TestClearAccessTokenCookie(t *testing.T) {
 	resp := httptest.NewRecorder()
 	p.clearAccessTokenCookie(req, resp)
 	assert.Contains(t, resp.Header().Get("Set-Cookie"),
-		accessCookie+"=; Path=/; Domain=127.0.0.1; Expires=",
+		accessCookie+"=; Path=/; Expires=",
 		"we have not cleared the, headers: %v", resp.Header())
 }
 
@@ -195,7 +195,7 @@ func TestClearRefreshAccessTokenCookie(t *testing.T) {
 	resp := httptest.NewRecorder()
 	p.clearRefreshTokenCookie(req, resp)
 	assert.Contains(t, resp.Header().Get("Set-Cookie"),
-		refreshCookie+"=; Path=/; Domain=127.0.0.1; Expires=",
+		refreshCookie+"=; Path=/; Expires=",
 		"we have not cleared the, headers: %v", resp.Header())
 }
 
@@ -205,7 +205,7 @@ func TestClearAllCookies(t *testing.T) {
 	resp := httptest.NewRecorder()
 	p.clearAllCookies(req, resp)
 	assert.Contains(t, resp.Header().Get("Set-Cookie"),
-		accessCookie+"=; Path=/; Domain=127.0.0.1; Expires=",
+		accessCookie+"=; Path=/; Expires=",
 		"we have not cleared the, headers: %v", resp.Header())
 }
 


### PR DESCRIPTION
By setting the domain attribute on the cookie we were allowing the
cookie to be applied to subdomains where it may not be valid and may
interfere with other services protected by keycloak-gatekeeper.

(For example, a gatekeeper running on https://domain.com could break a
gatekeeper running on https://sub.domain.com .)

Instead, we should simply not set the attribute unless there is
a specific domain configured.

For more information please see section 4.1.2.3 of [RFC 6265].

[RFC 6265]: https://tools.ietf.org/html/rfc6265#section-4.1.2

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
