### PR TITLE
[KEYCLOAK-10023] Prevent goproxy from deleting middleware headers  

### DIFF
--- a/server.go
+++ b/server.go
@@ -606,6 +606,7 @@ func (r *oauthProxy) createUpstreamProxy(upstream *url.URL) error {
 	// create the forwarding proxy
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Logger = httplog.New(ioutil.Discard, "", 0)
+	proxy.KeepDestinationHeaders = true
 	r.upstream = proxy
 
 	// update the tls configuration of the reverse proxy

--- a/server_test.go
+++ b/server_test.go
@@ -157,7 +157,7 @@ func TestRequestIDHeader(t *testing.T) {
 			ExpectedProxy: true,
 			Redirects:     true,
 			ExpectedHeaders: map[string]string{
-				"X-Request-ID": "",
+				c.RequestIDHeader: "",
 			},
 			ExpectedCode: http.StatusOK,
 		},
@@ -445,6 +445,7 @@ func newFakeKeycloakConfig() *Config {
 		ClientSecret:               fakeSecret,
 		CookieAccessName:           "kc-access",
 		CookieRefreshName:          "kc-state",
+		RequestIDHeader:            "X-Request-ID",
 		DisableAllLogging:          true,
 		DiscoveryURL:               "127.0.0.1:0",
 		EnableAuthorizationCookies: true,
@@ -525,8 +526,19 @@ type fakeUpstreamResponse struct {
 }
 
 // fakeUpstreamService acts as a fake upstream service, returns the headers and request
-type fakeUpstreamService struct{}
+type fakeUpstreamService struct {
+	server   *httptest.Server
+	location string
+}
 
+func newFakeUpstreamService() *fakeUpstreamService {
+	service := &fakeUpstreamService{}
+
+	service.server = httptest.NewServer(service)
+	service.location = service.server.URL
+
+	return service
+}
 func (f *fakeUpstreamService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(testProxyAccepted, "true")
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
By default, the goproxy middleware removes all headers from the given ResponseWriter before it adds the headers it has received from the upstream service. This includes all headers injected by the authenticationMiddleware, like a `Set-Cookie` with a refreshed access token.

Setting the `KeepDestinationHeaders` option to `true` should prevent this from happening.

Jira issue: https://issues.jboss.org/browse/KEYCLOAK-10023