### PR TITLE
[KEYCLOAK-11077] fix refresh token stores

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -391,7 +391,7 @@ type RequestScope struct {
 // the default practice of a encrypted cookie
 type storage interface {
 	// Set the token to the store
-	Set(string, string) error
+	Set(string, string, time.Duration) error
 	// Get retrieves a token from the store
 	Get(string) (string, error)
 	// Delete removes a key from the store

--- a/server.go
+++ b/server.go
@@ -613,6 +613,7 @@ func (r *oauthProxy) createUpstreamProxy(upstream *url.URL) error {
 	// and for refreshed cookies (htts://github.com/keycloak/keycloak-gatekeeper/pulls/456])
 	proxy.KeepDestinationHeaders = true
 	proxy.Logger = httplog.New(ioutil.Discard, "", 0)
+	proxy.KeepDestinationHeaders = true
 	r.upstream = proxy
 
 	// update the tls configuration of the reverse proxy

--- a/store_boltdb.go
+++ b/store_boltdb.go
@@ -60,7 +60,7 @@ func newBoltDBStore(location *url.URL) (storage, error) {
 }
 
 // Set adds a token to the store
-func (r *boltdbStore) Set(key, value string) error {
+func (r *boltdbStore) Set(key, value string, expiration time.Duration) error {
 	return r.client.Update(func(tx *bbolt.Tx) error {
 		bucket := tx.Bucket([]byte(dbName))
 		if bucket == nil {

--- a/store_boltdb_test.go
+++ b/store_boltdb_test.go
@@ -65,18 +65,21 @@ func TestNewBoltDBStore(t *testing.T) {
 func TestBoltSet(t *testing.T) {
 	s := newTestBoldDB(t)
 	defer s.close()
-	err := s.store.Set("test", "value")
+	err := s.store.Set("test", "value", 0)
 	assert.NoError(t, err)
 }
 
 func TestBoltGet(t *testing.T) {
 	s := newTestBoldDB(t)
 	defer s.close()
+
 	v, err := s.store.Get("test")
 	assert.NoError(t, err)
 	assert.Empty(t, v)
-	err = s.store.Set("test", "value")
+
+	err = s.store.Set("test", "value", 0)
 	assert.NoError(t, err)
+
 	v, err = s.store.Get("test")
 	assert.NoError(t, err)
 	assert.Equal(t, "value", v)
@@ -87,7 +90,7 @@ func TestBoltDelete(t *testing.T) {
 	value := "value"
 	s := newTestBoldDB(t)
 	defer s.close()
-	err := s.store.Set(keyname, value)
+	err := s.store.Set(keyname, value, 0)
 	assert.NoError(t, err)
 	v, err := s.store.Get(keyname)
 	assert.NoError(t, err)

--- a/store_redis.go
+++ b/store_redis.go
@@ -47,8 +47,8 @@ func newRedisStore(location *url.URL) (storage, error) {
 }
 
 // Set adds a token to the store
-func (r redisStore) Set(key, value string) error {
-	if err := r.client.Set(key, value, time.Duration(0)); err.Err() != nil {
+func (r redisStore) Set(key, value string, expiration time.Duration) error {
+	if err := r.client.Set(key, value, expiration); err.Err() != nil {
 		return err.Err()
 	}
 
@@ -62,7 +62,7 @@ func (r redisStore) Get(key string) (string, error) {
 		return "", result.Err()
 	}
 
-	return result.String(), nil
+	return result.Val(), nil
 }
 
 // Delete remove the key

--- a/stores.go
+++ b/stores.go
@@ -18,6 +18,7 @@ package main
 import (
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/coreos/go-oidc/jose"
 	"go.uber.org/zap"
@@ -50,8 +51,8 @@ func (r *oauthProxy) useStore() bool {
 }
 
 // StoreRefreshToken the token to the store
-func (r *oauthProxy) StoreRefreshToken(token jose.JWT, value string) error {
-	return r.store.Set(getHashKey(&token), value)
+func (r *oauthProxy) StoreRefreshToken(token jose.JWT, value string, expiration time.Duration) error {
+	return r.store.Set(getHashKey(&token), value, expiration)
 }
 
 // Get retrieves a token from the store, the key we are using here is the access token


### PR DESCRIPTION
This fixes multiple issues that make token stores currently unusable as described in [KEYCLOAK-11077](https://issues.jboss.org/browse/KEYCLOAK-11077)