### PR TITLE
[KEYCLOAK-11183] Fix linting errors reported by GolangCI on Gatekeeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,9 @@ vet:
 	fi
 
 lint:
-	@echo "--> Running golint"
-	@which golint 2>/dev/null ; if [ $$? -eq 1 ]; then \
-		go get -u github.com/golang/lint/golint; \
+	@echo "--> Running golangci-lint"
+	@which golangci-lint 2>/dev/null ; if [ $$? -eq 1 ]; then \
+		go get -u github.com/golangci/golangci-lint/cmd/golangci-lint; \
 	fi
 	@golint .
 
@@ -114,7 +114,7 @@ gofmt:
 
 verify:
 	@echo "--> Verifying the code"
-	gometalinter --disable=errcheck --disable=gocyclo --disable=gas --disable=aligncheck --errors
+	golangci-lint run
 
 format:
 	@echo "--> Running go fmt"

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -36,13 +36,16 @@ func TestCookieDomainHostHeader(t *testing.T) {
 			cookie = c
 		}
 	}
+	defer resp.Body.Close()
+
 	assert.NotNil(t, cookie)
 	assert.Equal(t, cookie.Domain, "127.0.0.1")
 }
 
 func TestCookieBasePath(t *testing.T) {
+	const baseURI = "/base-uri"
 	cfg := newFakeKeycloakConfig()
-	cfg.BaseURI = "/base-uri"
+	cfg.BaseURI = baseURI
 
 	_, _, svc := newTestProxyService(cfg)
 
@@ -52,12 +55,14 @@ func TestCookieBasePath(t *testing.T) {
 
 	var cookie *http.Cookie
 	for _, c := range resp.Cookies() {
-		if c.Name == "kc-access" {
+		if c.Name == accessCookie {
 			cookie = c
 		}
 	}
+	defer resp.Body.Close()
+
 	assert.NotNil(t, cookie)
-	assert.Equal(t, "/base-uri", cookie.Path)
+	assert.Equal(t, baseURI, cookie.Path)
 }
 
 func TestCookieWithoutBasePath(t *testing.T) {
@@ -71,10 +76,12 @@ func TestCookieWithoutBasePath(t *testing.T) {
 
 	var cookie *http.Cookie
 	for _, c := range resp.Cookies() {
-		if c.Name == "kc-access" {
+		if c.Name == accessCookie {
 			cookie = c
 		}
 	}
+	defer resp.Body.Close()
+
 	assert.NotNil(t, cookie)
 	assert.Equal(t, "/", cookie.Path)
 }
@@ -92,6 +99,8 @@ func TestCookieDomain(t *testing.T) {
 			cookie = c
 		}
 	}
+	defer resp.Body.Close()
+
 	assert.NotNil(t, cookie)
 	assert.Equal(t, cookie.Domain, "domain.com")
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -45,10 +45,12 @@ func checkListenOrBail(endpoint string) bool {
 		waitTime      = 100 * time.Millisecond
 	)
 	checkListen := http.Client{}
+	//nolint:bodyclose
 	_, err := checkListen.Get(endpoint)
 	limit := 0
 	for err != nil && limit < maxWaitCycles {
 		time.Sleep(waitTime)
+		//nolint:bodyclose
 		_, err = checkListen.Get(endpoint)
 		limit++
 	}
@@ -161,4 +163,5 @@ func TestCorsWithUpstream(t *testing.T) {
 		// check the returned upstream response after proxying contains CORS headers
 		assert.Equal(t, []string{"*"}, resp.Header["Access-Control-Allow-Origin"])
 	}
+	defer resp.Body.Close()
 }

--- a/handlers.go
+++ b/handlers.go
@@ -401,6 +401,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 				zap.Int("status", response.StatusCode),
 				zap.String("response", fmt.Sprintf("%s", content)))
 		}
+		defer response.Body.Close()
 	}
 	// step: should we redirect the user
 	if redirectURL != "" {

--- a/middleware.go
+++ b/middleware.go
@@ -126,7 +126,7 @@ func (r *oauthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 					next.ServeHTTP(w, req.WithContext(r.redirectToAuthorization(w, req)))
 					return
 				}
-			} else {
+			} else { //nolint:gocritic
 				if err := verifyToken(r.client, user.token); err != nil {
 					// step: if the error post verification is anything other than a token
 					// expired error we immediately throw an access forbidden - as there is

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -310,6 +310,7 @@ func (f *fakeProxy) performUserLogin(uri string) error {
 			}
 		}
 	}
+	defer resp.Body.Close()
 
 	return nil
 }

--- a/oauth.go
+++ b/oauth.go
@@ -124,6 +124,7 @@ func getUserinfo(client *oauth2.Client, endpoint string, token string) (jose.Cla
 	if err := json.Unmarshal(content, &claims); err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	return claims, nil
 }

--- a/server.go
+++ b/server.go
@@ -296,6 +296,7 @@ func (r *oauthProxy) createForwardingProxy() error {
 	if err := r.createUpstreamProxy(nil); err != nil {
 		return err
 	}
+	//nolint:bodyclose
 	forwardingHandler := r.forwardProxyHandler()
 
 	// set the http handler
@@ -453,7 +454,7 @@ func (r *oauthProxy) createHTTPListener(config listenerConfig) (net.Listener, er
 		if listener, err = net.Listen("unix", socket); err != nil {
 			return nil, err
 		}
-	} else {
+	} else { //nolint:gocritic
 		if listener, err = net.Listen("tcp", config.listen); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
 - Replace gometalinter by golangci-lint in the Makefile
 - Fix linting errors reported by golangci-lint

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
