### PR TITLE
Add SSL offloading detection to getRequestHostURL

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -121,7 +121,7 @@ func getRequestHostURL(r *http.Request) string {
 	}
 
 	scheme := "http"
-	if r.TLS != nil {
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 		scheme = "https"
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -120,9 +120,9 @@ func getRequestHostURL(r *http.Request) string {
 		hostname = r.Header.Get("X-Forwarded-Host")
 	}
 
-	scheme := "http"
-	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-		scheme = "https"
+	scheme := unsecureScheme
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == secureScheme {
+		scheme = secureScheme
 	}
 
 	return fmt.Sprintf("%s://%s", scheme, hostname)


### PR DESCRIPTION
When SSL is offloaded by a proxy, ie: Traefik, Nginx, etc., Gatekeeper does not detect that the end-user scheme is https for /oauth/logout (if no redirect value is specified).