### PR TITLE
[KEYCLOAK-12100] Add ISO8601 Time Encoder for logs timestamps.

### DIFF
--- a/config.go
+++ b/config.go
@@ -71,6 +71,7 @@ func newDefaultConfig() *Config {
 		UpstreamTLSHandshakeTimeout:   10 * time.Second,
 		UpstreamTimeout:               10 * time.Second,
 		UseLetsEncrypt:                false,
+		EnableISO8601TimeEncoder:      false,
 	}
 }
 

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -12,6 +12,8 @@ listen: 127.0.0.1:3000
 enable-refresh-tokens: true
 # log all incoming requests
 enable-logging: true
+# timeformat for timestamp to be set as iso8601.
+enable-iso8601-time-encoder: false
 # log in json format
 enable-json-logging: true
 # should the access token be encrypted - you need an encryption-key if 'true'

--- a/doc.go
+++ b/doc.go
@@ -217,6 +217,8 @@ type Config struct {
 	EnableLogging bool `json:"enable-logging" yaml:"enable-logging" usage:"enable http logging of the requests"`
 	// EnableJSONLogging is the logging format
 	EnableJSONLogging bool `json:"enable-json-logging" yaml:"enable-json-logging" usage:"switch on json logging rather than text"`
+	// EnableISO8601TimeEncoder indicates if ISO8601 format timestamp logging is enabled.
+	EnableISO8601TimeEncoder bool `json:"enable-iso8601-time-encoder" yaml:"enable-iso8601-time-encoder" usage:"switch on ISO8601 format TimeStamp logging."`
 	// EnableForwarding enables the forwarding proxy
 	EnableForwarding bool `json:"enable-forwarding" yaml:"enable-forwarding" usage:"enables the forwarding proxy mode, signing outbound request"`
 	// EnableSecurityFilter enabled the security handler

--- a/server.go
+++ b/server.go
@@ -45,6 +45,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type oauthProxy struct {
@@ -135,6 +136,9 @@ func createLogger(config *Config) (*zap.Logger, error) {
 	}
 
 	c := zap.NewProductionConfig()
+	if config.EnableISO8601TimeEncoder {
+		c.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	}
 	c.DisableStacktrace = true
 	c.DisableCaller = true
 	// are we enabling json logging?


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Hi
This is a PR for including the formating of the timestamp in logs for human readability and security audits. This is my first PR, with a plausible simple approach. Please guide me further on the approach. 