### PR TITLE
KEYCLOAK-11499

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -153,6 +153,8 @@ type Resource struct {
 
 // Config is the configuration for the proxy
 type Config struct {
+	// IdpHint
+	IdpHint string `json:"idp-hint" yaml:"idp-hint" usage:"idp hint name configuration" env:"IDP_HINT"`
 	// ConfigFile is the binding interface
 	ConfigFile string `json:"config" yaml:"config" usage:"path the a configuration file" env:"CONFIG_FILE"`
 	// Listen is the binding interface

--- a/handlers.go
+++ b/handlers.go
@@ -85,6 +85,12 @@ func (r *oauthProxy) oauthAuthorizationHandler(w http.ResponseWriter, req *http.
 	}
 
 	authURL := client.AuthCodeURL(req.URL.Query().Get("state"), accessType, "")
+	// idp_hint config
+	idpHint := r.config.IdpHint
+	if idpHint != "" {
+		authURL += "&kc_idp_hint=" + idpHint
+	}
+
 	r.log.Debug("incoming authorization request from client address",
 		zap.String("access_type", accessType),
 		zap.String("auth_url", authURL),


### PR DESCRIPTION
 Add `idp-hint` as a configuration option, so that gatekeeper can set it's own suggested idp.