### PR TITLE
[KEYCLOAK-12433] Ingest --tags, --response-headers from CLI options

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -160,7 +160,7 @@ func getCommandLineOptions() []cli.Flag {
 // parseCLIOptions parses the command line options and constructs a config object
 func parseCLIOptions(cx *cli.Context, config *Config) (err error) {
 	// step: we can ignore these options in the Config struct
-	ignoredOptions := []string{"tag-data", "match-claims", "resources", "headers"}
+	ignoredOptions := []string{"tags", "match-claims", "resources", "headers", "response-headers"}
 	// step: iterate the Config and grab command line options via reflection
 	count := reflect.TypeOf(config).Elem().NumField()
 	for i := 0; i < count; i++ {
@@ -190,8 +190,8 @@ func parseCLIOptions(cx *cli.Context, config *Config) (err error) {
 			}
 		}
 	}
-	if cx.IsSet("tag") {
-		tags, err := decodeKeyPairs(cx.StringSlice("tag"))
+	if cx.IsSet("tags") {
+		tags, err := decodeKeyPairs(cx.StringSlice("tags"))
 		if err != nil {
 			return err
 		}
@@ -210,6 +210,13 @@ func parseCLIOptions(cx *cli.Context, config *Config) (err error) {
 			return err
 		}
 		mergeMaps(config.Headers, headers)
+	}
+	if cx.IsSet("response-headers") {
+		responseHeaders, err := decodeKeyPairs(cx.StringSlice("response-headers"))
+		if err != nil {
+			return err
+		}
+		mergeMaps(config.ResponseHeaders, responseHeaders)
 	}
 	if cx.IsSet("resources") {
 		for _, x := range cx.StringSlice("resources") {

--- a/utils.go
+++ b/utils.go
@@ -212,11 +212,11 @@ func decodeKeyPairs(list []string) (map[string]string, error) {
 	kp := make(map[string]string)
 
 	for _, x := range list {
-		items := strings.Split(x, "=")
-		if len(items) != 2 {
-			return kp, fmt.Errorf("invalid tag '%s' should be key=pair", x)
+		splitIdx := strings.Index(x, "=")
+		if splitIdx < 0 {
+			return kp, fmt.Errorf("invalid tag '%s', should be key=pair", x)
 		}
-		kp[items[0]] = items[1]
+		kp[x[:splitIdx]] = x[splitIdx+1:]
 	}
 
 	return kp, nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -39,10 +39,11 @@ func TestDecodeKeyPairs(t *testing.T) {
 		Ok       bool
 	}{
 		{
-			List: []string{"a=b", "b=3"},
+			List: []string{"a=b", "b=3", "c=d=e"},
 			KeyPairs: map[string]string{
 				"a": "b",
 				"b": "3",
+				"c": "d=e",
 			},
 			Ok: true,
 		},


### PR DESCRIPTION
This PR addresses KEYCLOAK-12433, the `--flags` CLI option would not be parsed.
See [JIRA issue](https://issues.redhat.com/browse/KEYCLOAK-12433) for further details.

Changes include:
- Allow the `--flags` and `--response-headers` CLI options to be ingested
- Test that ensures all map based CLI options as defined in the config get parsed
- decodeKeyPairs agnostic of value on right side of assignment (ie, can include the `=` character)
- Test decodeKeyPairs updated to ensure value parsing is agnostic