### PR TITLE
Verify upstream certificate by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,7 +62,7 @@ func newDefaultConfig() *Config {
 		ServerReadTimeout:             10 * time.Second,
 		ServerWriteTimeout:            10 * time.Second,
 		SkipOpenIDProviderTLSVerify:   false,
-		SkipUpstreamTLSVerify:         true,
+		SkipUpstreamTLSVerify:         false,
 		Tags:                          make(map[string]string),
 		UpstreamExpectContinueTimeout: 10 * time.Second,
 		UpstreamKeepaliveTimeout:      10 * time.Second,


### PR DESCRIPTION
Hi guys,

Just spotted this and wanted to _quickly_ raise it. (You've disabled issues so it's not easy to do so!)

Is this really a good default to have? Wouldn't it be better to verify by default and only skip verification if the user explicitly demands it?

Apologies if I'm missing something!