### PR TITLE
[WIP] forward auth mode

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -64,15 +64,16 @@ const (
 	claimResourceRoles  = "roles"
 	claimGroups         = "groups"
 
-	accessCookie       = "kc-access"
-	refreshCookie      = "kc-state"
-	requestURICookie   = "request_uri"
-	requestStateCookie = "OAuth_Token_Request_State"
-	unsecureScheme     = "http"
-	secureScheme       = "https"
-	anyMethod          = "ANY"
-	authMethodBasic    = "secret-basic"
-	authMethodBody     = "secret-body"
+	accessCookie        = "kc-access"
+	refreshCookie       = "kc-state"
+	requestURICookie    = "request_uri"
+	requestStateCookie  = "OAuth_Token_Request_State"
+	unsecureScheme      = "http"
+	secureScheme        = "https"
+	anyMethod           = "ANY"
+	authMethodBasic     = "secret-basic"
+	authMethodBody      = "secret-body"
+	forwardAuthUpstream = "none"
 
 	_ contextKey = iota
 	contextScopeName
@@ -183,7 +184,7 @@ type Config struct {
 	// Scopes is a list of scope we should request
 	Scopes []string `json:"scopes" yaml:"scopes" usage:"list of scopes requested when authenticating the user"`
 	// Upstream is the upstream endpoint i.e whom were proxying to
-	Upstream string `json:"upstream-url" yaml:"upstream-url" usage:"url for the upstream endpoint you wish to proxy" env:"UPSTREAM_URL"`
+	Upstream string `json:"upstream-url" yaml:"upstream-url" usage:"url for the upstream endpoint you wish to proxy. If 'none' it will return 200 code." env:"UPSTREAM_URL"`
 	// UpstreamCA is the path to a CA certificate in PEM format to validate the upstream certificate
 	UpstreamCA string `json:"upstream-ca" yaml:"upstream-ca" usage:"the path to a file container a CA certificate to validate the upstream tls endpoint"`
 	// Resources is a list of protected resources
@@ -364,6 +365,8 @@ type Config struct {
 
 	// DisableAllLogging indicates no logging at all
 	DisableAllLogging bool `json:"disable-all-logging" yaml:"disable-all-logging" usage:"disables all logging to stdout and stderr"`
+	// Hostname mode
+	HostnameMode bool `json:"hostname-mode" yaml:"hostname-mode" usage:"check hostname in uri. URI Example: /my.app.com/*"`
 }
 
 // getVersion returns the proxy version

--- a/server.go
+++ b/server.go
@@ -189,8 +189,14 @@ func (r *oauthProxy) createReverseProxy() error {
 		})
 		engine.Use(c.Handler)
 	}
-
-	engine.Use(r.proxyMiddleware)
+	// proxying request only if not forward auth mode
+	if r.config.Upstream != forwardAuthUpstream {
+		engine.Use(r.proxyMiddleware)
+	}
+	// modify request in hostname mode
+	if r.config.HostnameMode {
+		engine.Use(r.hostnameMiddleware)
+	}
 	r.router = engine
 
 	if len(r.config.ResponseHeaders) > 0 {

--- a/utils.go
+++ b/utils.go
@@ -113,19 +113,24 @@ func createCertificate(key *rsa.PrivateKey, hostnames []string, expire time.Dura
 	return tls.X509KeyPair(certPEM, keyPEM)
 }
 
-// getRequestHostURL returns the hostname from the request
-func getRequestHostURL(r *http.Request) string {
+// getRequestHost returns the hostname from the request
+func getRequestHost(r *http.Request) string {
 	hostname := r.Host
 	if r.Header.Get("X-Forwarded-Host") != "" {
 		hostname = r.Header.Get("X-Forwarded-Host")
 	}
 
+	return hostname
+}
+
+// getRequestHostURL returns the hostname from the request
+func getRequestHostURL(r *http.Request) string {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
 	}
 
-	return fmt.Sprintf("%s://%s", scheme, hostname)
+	return fmt.Sprintf("%s://%s", scheme, getRequestHost(r))
 }
 
 // readConfigFile reads and parses the configuration file


### PR DESCRIPTION
Please check.

I've added “forward auth” mode and support for filtering by proxying hostname.
In order to activate forward auth mode you need set upstream-url: **none**
In this mode gatekeeper will not proxy request and answer 200 or 403 error code. It’s useful in balancers that support forward auth.  [Traefik](https://github.com/containous/traefik) for example.
Also I've added support for filtering by hostname. In this mode you can specify request hostname in URI.
```
hostname-mode: true
resources:
- uri: /my.app.com/admin*
  roles:
  - client:admin
- uri: /my.app.com/*
  roles:
  - user
```
