### PR TITLE
[KEYCLOAK-13165] Add Host into header

### DIFF
--- a/forwarding.go
+++ b/forwarding.go
@@ -40,6 +40,7 @@ func (r *oauthProxy) proxyMiddleware(next http.Handler) http.Handler {
 		}
 
 		// @step: add the proxy forwarding headers
+		req.Header.Set("Host", req.Host)
 		req.Header.Add("X-Forwarded-For", realIP(req))
 		req.Header.Set("X-Forwarded-Host", req.Host)
 		req.Header.Set("X-Forwarded-Proto", req.Header.Get("X-Forwarded-Proto"))


### PR DESCRIPTION
Add Host to the forwarding headers to make a more standard behavior

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
