### PR TITLE
[KEYCLOAK-12100] Custom Logging Time Format

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -364,6 +364,8 @@ type Config struct {
 
 	// DisableAllLogging indicates no logging at all
 	DisableAllLogging bool `json:"disable-all-logging" yaml:"disable-all-logging" usage:"disables all logging to stdout and stderr"`
+	// LoggingTimeFormat indicates the set time format (epoch, millis, nano, or iso8601)
+	LoggingTimeFormat string `json:"logging-time-format" yaml:"logging-time-format" usage:"logging time format can be set to epoch, millis, nano, or iso8601" `
 }
 
 // getVersion returns the proxy version

--- a/server.go
+++ b/server.go
@@ -45,7 +45,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 type oauthProxy struct {
@@ -150,17 +149,7 @@ func createLogger(config *Config) (*zap.Logger, error) {
 		c.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	}
 	// Set Time Logging Format
-	switch strings.ToLower(config.LoggingTimeFormat) {
-	case "iso8601":
-		c.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-	case "millis":
-		c.EncoderConfig.EncodeTime = zapcore.EpochMillisTimeEncoder
-	case "nanos":
-		c.EncoderConfig.EncodeTime = zapcore.EpochNanosTimeEncoder
-	default:
-		c.EncoderConfig.EncodeTime = zapcore.EpochTimeEncoder
-	}
-
+	c.EncoderConfig.EncodeTime.UnmarshalText([]byte(config.LoggingTimeFormat))
 	return c.Build()
 }
 

--- a/server.go
+++ b/server.go
@@ -45,6 +45,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type oauthProxy struct {
@@ -147,6 +148,17 @@ func createLogger(config *Config) (*zap.Logger, error) {
 		c.DisableCaller = false
 		c.Development = true
 		c.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	}
+	// Set Time Logging Format
+	switch strings.ToLower(config.LoggingTimeFormat) {
+	case "iso8601":
+		c.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	case "millis":
+		c.EncoderConfig.EncodeTime = zapcore.EpochMillisTimeEncoder
+	case "nanos":
+		c.EncoderConfig.EncodeTime = zapcore.EpochNanosTimeEncoder
+	default:
+		c.EncoderConfig.EncodeTime = zapcore.EpochTimeEncoder
 	}
 
 	return c.Build()

--- a/server.go
+++ b/server.go
@@ -147,9 +147,12 @@ func createLogger(config *Config) (*zap.Logger, error) {
 		c.DisableCaller = false
 		c.Development = true
 		c.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	}
+    }
 	// Set Time Logging Format
-	c.EncoderConfig.EncodeTime.UnmarshalText([]byte(config.LoggingTimeFormat))
+    err := c.EncoderConfig.EncodeTime.UnmarshalText([]byte(config.LoggingTimeFormat))
+    if(err != nil){
+        retur nil,err
+    }
 	return c.Build()
 }
 


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Initial design idea to add Custom Logging Time Format. 
As per the existing design, we are setting up a production configuration by default. 
 we have below mentioned flags related to zap logging configuration.
- enable-json-logging:  To switch to JSON or back to console(text) logging.
- disable-all-logging: Disable All Logging
- verbose: Uses Development and Debug Logging Level. 

I propose we add below extra configuration parameters. 
- logging-time-format: logging time format can be set to epoch, millis, nano, or iso8601. (Added in Pull Request )
